### PR TITLE
Use fqn name for extension type mapping

### DIFF
--- a/.changeset/rude-coats-repeat.md
+++ b/.changeset/rude-coats-repeat.md
@@ -1,0 +1,5 @@
+---
+"silverstripe-rector": patch
+---
+
+Use FQN name for extension type mapping

--- a/src/StaticTypeMapper/PhpDocParser/ExtensionTypeMapper.php
+++ b/src/StaticTypeMapper/PhpDocParser/ExtensionTypeMapper.php
@@ -13,13 +13,13 @@ use PHPStan\PhpDocParser\Ast\Type\IntersectionTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\StaticType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use Rector\StaticTypeMapper\Contract\PhpDocParser\PhpDocTypeMapperInterface;
+use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedGenericObjectType;
 use SilverStripe\Core\Extensible;
 use SilverStripe\Core\Extension;
 use function count;
@@ -65,7 +65,7 @@ final readonly class ExtensionTypeMapper implements PhpDocTypeMapperInterface
             return $this->typeNodeResolver->resolve($typeNode, $nameScope);
         }
 
-        return new GenericObjectType($typeNode->type->name, $genericTypes);
+        return new FullyQualifiedGenericObjectType($nameScope->resolveStringName($typeNode->type->name), $genericTypes);
     }
 
     private function resolveUnionTypeNode(UnionTypeNode $typeNode, NameScope $nameScope): Type

--- a/tests/rules/Silverstripe52/Rector/Class_/AddExtendsAnnotationToExtensionRector/Fixture/extension_shortname.php.inc
+++ b/tests/rules/Silverstripe52/Rector/Class_/AddExtendsAnnotationToExtensionRector/Fixture/extension_shortname.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\Silverstripe52\Rector\Class_\AddExtendsAnnotationToExtensionRector\Fixture;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Dev\TestOnly;
+
+/**
+ * @extends Extension<static>
+ */
+class ExtensionShortname extends Extension implements TestOnly
+{
+}


### PR DESCRIPTION

## Description ✍️

- This resolves an issue where we were potentially comparing an fqn name vs a short name. Which will always return false.

## Fixes 🐛

The following comparison which potentially compares a fqn name against a short name. https://github.com/Cambis/silverstripe-rector/blob/9ceafd4b155f7c6b4c894c5dd297056ab9fcd7dd/src/PhpDocManipulator/AnnotationUpdater.php#L160

Now both types should include their fqn classnames.


## DoD checklist ✅

- [x] I have performed a self-review of my code
- [x] My code adheres to the [coding standards](../CONTRIBUTING.md#coding-standards-️)
- [x] My commit messages adhere to the [commit standards](../CONTRIBUTING.md#commit-standards-️).
- [x] My code has been [tested](../CONTRIBUTING.md#testing-).
- [x] I have added a [changeset](../CONTRIBUTING.md#making-a-pull-request-).
