### PR TITLE
Remove `silverstripe/cms` from dependencies

### DIFF
--- a/.changeset/odd-trainers-fold.md
+++ b/.changeset/odd-trainers-fold.md
@@ -1,0 +1,5 @@
+---
+"silverstripe-rector": minor
+---
+
+Remove silverstripe/cms from dependencies

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ See available [Silverstripe rules](docs/rector_rules_overview.md).
 ```sh
 php ^7.4 || ^8.0
 silverstripe/framework ^4.0 || ^5.0
-silverstripe/cms ^4.0 || ^5.0
 ```
 
 ## Installation 👷‍♀️

--- a/build/composer-php-74.json
+++ b/build/composer-php-74.json
@@ -9,7 +9,6 @@
   "require": {
       "php": "^7.4 || ^8.0",
       "rector/rector": "^1.0",
-      "silverstripe/cms": "^4.0 || ^5.0",
       "silverstripe/framework": "^4.0 || ^5.0",
       "webmozart/assert": "^1.11"
   },

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
     "require": {
         "php": "^8.3",
         "rector/rector": "^1.0",
-        "silverstripe/cms": "^4.0 || ^5.0",
         "silverstripe/framework": "^4.0 || ^5.0",
         "webmozart/assert": "^1.11"
     },
@@ -22,6 +21,7 @@
         "phpstan/phpstan-phpunit": "^1.3",
         "phpstan/phpstan-strict-rules": "^1.5",
         "phpunit/phpunit": "^9.6",
+        "silverstripe/cms": "^4.0 || ^5.0",
         "slevomat/coding-standard": "^8.14",
         "symplify/easy-coding-standard": "^12.0",
         "symplify/phpstan-extensions": "^11.4",

--- a/ecs.php
+++ b/ecs.php
@@ -32,4 +32,9 @@ return ECSConfig::configure()
         '*/Source/*',
         '*/Source*',
         NotOperatorWithSuccessorSpaceFixer::class,
+        ReferenceUsedNamesOnlySniff::class => [
+            __DIR__ . '/bootstrap.php',
+            __DIR__ . '/stubs/Page.php',
+            __DIR__ . '/stubs/PageController.php',
+        ],
     ]);

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -17,6 +17,8 @@ parameters:
     - '*tests/*/Source/*'
     - '*tests/*/Source*'
     - '*tests/*/config/*'
+    - stubs/Page.php
+    - stubs/PageController.php
   cognitive_complexity:
       class: 50
       function: 15

--- a/rules/Silverstripe52/Rector/Class_/AddExtendsAnnotationToContentControllerRector.php
+++ b/rules/Silverstripe52/Rector/Class_/AddExtendsAnnotationToContentControllerRector.php
@@ -15,8 +15,6 @@ use PHPStan\Reflection\ClassReflection;
 use Rector\BetterPhpDocParser\ValueObject\PhpDoc\SpacingAwareTemplateTagValueNode;
 use Rector\Exception\ShouldNotHappenException;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
-use SilverStripe\CMS\Controllers\ContentController;
-use SilverStripe\CMS\Model\SiteTree;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -99,14 +97,16 @@ CODE_SAMPLE
         $dataRecordType = new FullyQualifiedObjectType($dataRecordClassName);
 
         // Verify the dataRecord
-        if ((new FullyQualifiedObjectType(SiteTree::class))->isSuperTypeOf($dataRecordType)->no()) {
+        if ((new FullyQualifiedObjectType('SilverStripe\\CMS\\Model\\SiteTree'))->isSuperTypeOf($dataRecordType)->no()) {
             return [];
         }
 
         $dataRecordTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPHPStanPhpDocTypeNode($dataRecordType);
+
+        /** @var string $parentClassName */
         $parentClassName = $this->getParentClassName($classReflection);
 
-        if ($parentClassName === ContentController::class) {
+        if ($parentClassName === 'SilverStripe\\CMS\\Controllers\\ContentController') {
             $tagValueNodes[] = new SpacingAwareTemplateTagValueNode(
                 'T',
                 $this->staticTypeMapper->mapPHPStanTypeToPHPStanPhpDocTypeNode($dataRecordType),
@@ -156,7 +156,7 @@ CODE_SAMPLE
 
         $classReflection = $this->reflectionProvider->getClass($className);
 
-        return !$classReflection->isSubclassOf(ContentController::class);
+        return !$classReflection->isSubclassOf('SilverStripe\\CMS\\Controllers\\ContentController');
     }
 
     /**

--- a/stubs/Page.php
+++ b/stubs/Page.php
@@ -3,6 +3,10 @@
 namespace {
     use SilverStripe\CMS\Model\SiteTree;
 
+    if (!class_exists(SilverStripe\CMS\Model\SiteTree::class)) {
+        return;
+    }
+
     class Page extends SiteTree
     {
     }

--- a/stubs/PageController.php
+++ b/stubs/PageController.php
@@ -3,6 +3,10 @@
 namespace {
     use SilverStripe\CMS\Controllers\ContentController;
 
+    if (!class_exists(SilverStripe\CMS\Controllers\ContentController::class)) {
+        return;
+    }
+
     class PageController extends ContentController
     {
     }


### PR DESCRIPTION
## Description ✍️

- The goal of this change is to make it easier to use this module inside of a Silverstripe module. Not all Silverstripe modules are dependent on silverstripe/cms.
- During testing this module on a Silverstripe module, I ran into an issue where composer was installing a pre-release version of silverstripe/cms which was causing issues.
- Any class consts referencing silverstripe/cms have been transformed into fq strings
- Update the Page/PageController stub files

## DoD checklist ✅

- [x] I have performed a self-review of my code
- [x] My code adheres to the [coding standards](../CONTRIBUTING.md#coding-standards-️)
- [x] My commit messages adhere to the [commit standards](../CONTRIBUTING.md#commit-standards-️).
- [x] My code has been [tested](../CONTRIBUTING.md#testing-).
- [x] I have added a [changeset](../CONTRIBUTING.md#making-a-pull-request-).
