### PR TITLE
Add generated test classes to silverstripe manifest

### DIFF
--- a/.changeset/eight-rocks-collect.md
+++ b/.changeset/eight-rocks-collect.md
@@ -1,0 +1,5 @@
+---
+"silverstripe-rector": minor
+---
+
+Add generated test files to Silverstripe manifest

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "symplify/phpstan-extensions": "^11.4",
         "symplify/phpstan-rules": "^13.0",
         "symplify/rule-doc-generator": "^11.0",
+        "symplify/vendor-patches": "^11.3",
         "tomasvotruba/cognitive-complexity": "^0.2.2"
     },
     "minimum-stability": "dev",
@@ -62,6 +63,9 @@
     "extra": {
         "composer-exit-on-patch-failure": true,
         "patches": {
+            "rector/rector": {
+                "Update Silverstripe class manifest": "patches/rector/rector/update-silverstripe-class-manifest.patch"
+            },
             "symplify/rule-doc-generator": {
                 "Custom rule docs": "patches/symplify/rule-doc-generator/custom-rule-docs.patch"
             }

--- a/patches/rector/rector/update-silverstripe-class-manifest.patch
+++ b/patches/rector/rector/update-silverstripe-class-manifest.patch
@@ -1,0 +1,18 @@
+--- /dev/null
++++ ../src/Testing/PHPUnit/AbstractRectorTestCase.php
+@@ -3,6 +3,7 @@
+ declare (strict_types=1);
+ namespace Rector\Testing\PHPUnit;
+ 
++use Cambis\SilverstripeRector\Testing\Fixture\FixtureManifestUpdater;
+ use RectorPrefix202408\Illuminate\Container\RewindableGenerator;
+ use Iterator;
+ use RectorPrefix202408\Nette\Utils\FileSystem;
+@@ -135,6 +136,7 @@
+         }
+         // write temp file
+         FileSystem::write($inputFilePath, $inputFileContents, null);
++        FixtureManifestUpdater::addInputFileToClassManifest($inputFilePath);
+         $this->doTestFileMatchesExpectedContent($inputFilePath, $inputFileContents, $expectedFileContents, $fixtureFilePath);
+     }
+     private function forgetRectorsRules() : void

--- a/rector.php
+++ b/rector.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector;
 use Rector\Php83\Rector\ClassConst\AddTypeToConstRector;
 use Rector\Set\ValueObject\LevelSetList;
@@ -27,4 +28,8 @@ return RectorConfig::configure()
         ClosureToArrowFunctionRector::class,
         // This may cause a downgrade to fail
         AddTypeToConstRector::class,
+        // This rector uses FQN names
+        StringClassNameToClassConstantRector::class => [
+            __DIR__ . '/rules/Silverstripe52/Rector/Class_/AddExtendsAnnotationToContentControllerRector.php',
+        ],
     ]);

--- a/src/Testing/Fixture/FixtureManifestUpdater.php
+++ b/src/Testing/Fixture/FixtureManifestUpdater.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\SilverstripeRector\Testing\Fixture;
+
+use SilverStripe\Core\ClassInfo;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Core\Injector\InjectorLoader;
+use SilverStripe\Core\Manifest\ClassLoader;
+use SilverStripe\Core\Manifest\ClassManifest;
+use function dirname;
+
+final class FixtureManifestUpdater
+{
+    /**
+     * Add the generated input file to the Silverstipe manifest, so any generated classes will be available to the Silverstripe API.
+     */
+    public static function addInputFileToClassManifest(string $inputFilePath): void
+    {
+        // We are not running Silverstripe so let's return
+        if (InjectorLoader::inst()->countManifests() === 0) {
+            return;
+        }
+
+        // Set the base path to the current directory, we only want to search files
+        // in the fixture directory
+        $basePath = dirname($inputFilePath);
+
+        // Create a new class manifest with the generated file
+        $classManifest = new ClassManifest($basePath);
+        $classManifest->handleFile($basePath, $inputFilePath, true);
+
+        // Add the manifest to the class loader
+        ClassLoader::inst()->pushManifest($classManifest, false);
+
+        // Register any new classes with the Injector
+        foreach (ClassInfo::classes_for_file($inputFilePath) as $class) {
+            Injector::inst()
+                ->load([$class])
+                ->create($class);
+        }
+    }
+}

--- a/src/Testing/Fixture/FixtureManifestUpdater.php
+++ b/src/Testing/Fixture/FixtureManifestUpdater.php
@@ -11,6 +11,9 @@ use SilverStripe\Core\Manifest\ClassLoader;
 use SilverStripe\Core\Manifest\ClassManifest;
 use function dirname;
 
+/**
+ * @see \Cambis\SilverstripeRector\Tests\Testing\Fixture\FixtureManifestUpdater\FixtureManifestUpdaterTest
+ */
 final class FixtureManifestUpdater
 {
     /**

--- a/tests/_config.php
+++ b/tests/_config.php
@@ -1,0 +1,3 @@
+<?php
+
+// This file is here so the classes inside in this directory become available to the Silverstripe manifest

--- a/tests/src/Testing/Fixture/FixtureManifestUpdater/Fixture/foo.php.inc
+++ b/tests/src/Testing/Fixture/FixtureManifestUpdater/Fixture/foo.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\Testing\Fixture\FixtureManifestUpdater\Fixture;
+
+class Foo extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+{
+}

--- a/tests/src/Testing/Fixture/FixtureManifestUpdater/FixtureManifestUpdaterTest.php
+++ b/tests/src/Testing/Fixture/FixtureManifestUpdater/FixtureManifestUpdaterTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\SilverstripeRector\Tests\Testing\Fixture\FixtureManifestUpdater;
+
+use Cambis\SilverstripeRector\Set\ValueObject\SilverstripeSetList;
+use Cambis\SilverstripeRector\Testing\Fixture\FixtureManifestUpdater;
+use Nette\Utils\FileSystem;
+use Nette\Utils\Strings;
+use Override;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use SilverStripe\Core\ClassInfo;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Core\Manifest\ClassLoader;
+
+final class FixtureManifestUpdaterTest extends AbstractRectorTestCase
+{
+    private ?string $inputFilePath = null;
+
+    public function testAddInputFileToClassManifest(): void
+    {
+        $this->inputFilePath = __DIR__ . '/Fixture/foo.php';
+
+        $expectedClassName = 'Cambis\SilverstripeRector\Tests\Testing\Fixture\FixtureManifestUpdater\Fixture\Foo';
+        $fixtureFilePath = __DIR__ . '/Fixture/foo.php.inc';
+
+        FileSystem::write($this->inputFilePath, FileSystem::read($fixtureFilePath));
+        FixtureManifestUpdater::addInputFileToClassManifest($this->inputFilePath);
+
+        $this->assertArrayHasKey(Strings::lower($expectedClassName), ClassLoader::inst()->getManifest()->getClassNames());
+        $this->assertTrue(ClassInfo::exists($expectedClassName));
+        $this->assertTrue(Injector::inst()->has($expectedClassName));
+        $this->assertInstanceOf($expectedClassName, Injector::inst()->create($expectedClassName));
+    }
+
+    #[Override]
+    public function provideConfigFilePath(): string
+    {
+        return SilverstripeSetList::WITH_SILVERSTRIPE_API;
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->inputFilePath !== null) {
+            FileSystem::delete($this->inputFilePath);
+        }
+    }
+}


### PR DESCRIPTION
## Description ✍️

Add generated test classes to Silverstripe manifest during testing.

## Fixes 🐛

- #9

## DoD checklist ✅

- [x] I have performed a self-review of my code
- [x] My code adheres to the [coding standards](../CONTRIBUTING.md#coding-standards-️)
- [x] My commit messages adhere to the [commit standards](../CONTRIBUTING.md#commit-standards-️).
- [x] My code has been [tested](../CONTRIBUTING.md#testing-).
- [x] I have added a [changeset](../CONTRIBUTING.md#making-a-pull-request-).
