### PR TITLE
Use phpstan types to check for array like argument

### DIFF
--- a/.changeset/young-elephants-develop.md
+++ b/.changeset/young-elephants-develop.md
@@ -1,0 +1,5 @@
+---
+"silverstripe-rector": patch
+---
+
+Fix for array like comparison in FieldListFieldsToTabNonArrayToArrayArgumentRector

--- a/rules/Silverstripe53/Rector/MethodCall/FieldListFieldsToTabNonArrayToArrayArgumentRector.php
+++ b/rules/Silverstripe53/Rector/MethodCall/FieldListFieldsToTabNonArrayToArrayArgumentRector.php
@@ -8,7 +8,6 @@ use Cambis\SilverstripeRector\ValueObject\SilverstripeConstants;
 use Override;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
-use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Type\ObjectType;
 use Rector\Rector\AbstractRector;
@@ -82,7 +81,7 @@ CODE_SAMPLE
 
         $argValue = $arg->value;
 
-        if ($argValue instanceof Array_) {
+        if ($this->getType($argValue)->isArray()->yes()) {
             return null;
         }
 

--- a/tests/rules/Silverstripe53/Rector/MethodCall/FieldListFieldsToTabNonArrayToArrayArgumentRector/Fixture/add_fields_to_tab_complete.php.inc
+++ b/tests/rules/Silverstripe53/Rector/MethodCall/FieldListFieldsToTabNonArrayToArrayArgumentRector/Fixture/add_fields_to_tab_complete.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\Silverstripe53\Rector\MethodCall\FieldListFieldsToTabNonArrayToArrayArgumentRector\Fixture;
+
+$fields = [\SilverStripe\Forms\TextField::create('Field')];
+
+\SilverStripe\Forms\FieldList::create()
+    ->addFieldsToTab('Root.Main', $fields);

--- a/tests/rules/Silverstripe53/Rector/MethodCall/FieldListFieldsToTabNonArrayToArrayArgumentRector/Fixture/remove_fields_from_tab_complete.php.inc
+++ b/tests/rules/Silverstripe53/Rector/MethodCall/FieldListFieldsToTabNonArrayToArrayArgumentRector/Fixture/remove_fields_from_tab_complete.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\Silverstripe53\Rector\MethodCall\FieldListFieldsToTabNonArrayToArrayArgumentRector\Fixture;
+
+$fields = [\SilverStripe\Forms\TextField::create('Field')];
+
+\SilverStripe\Forms\FieldList::create()
+    ->removeFieldsFromTab('Root.Main', $fields);


### PR DESCRIPTION
## Description ✍️

- Checking if the argument is an array argument is an instanceof Array_ isn't always truthy. Updated to use the phpstan types to check if the argument is an array.

## Fixes 🐛

- #20 

## DoD checklist ✅

- [x] I have performed a self-review of my code
- [x] My code adheres to the [coding standards](../CONTRIBUTING.md#coding-standards-️)
- [x] My commit messages adhere to the [commit standards](../CONTRIBUTING.md#commit-standards-️).
- [x] My code has been [tested](../CONTRIBUTING.md#testing-).
- [x] I have added a [changeset](../CONTRIBUTING.md#making-a-pull-request-).
