### PR TITLE
Use RelatedConfigInterface

### DIFF
--- a/.changeset/moody-rocks-eat.md
+++ b/.changeset/moody-rocks-eat.md
@@ -1,0 +1,5 @@
+---
+"@cambis/silverstripe-rector": patch
+---
+
+Use RelatedConfigInterface to import required services

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,6 +43,9 @@ jobs:
             php-version: 8.1
             framework-version: 5.3
             cms-version: 5.3
+          - directory: e2e/rename-data-extension-subclass
+            php-version: 8.1
+            framework-version: 5.3
     steps:
       # Build source code
       - uses: actions/checkout@v4

--- a/config/config.php
+++ b/config/config.php
@@ -2,11 +2,6 @@
 
 declare(strict_types=1);
 
-use Cambis\SilverstripeRector\Set\ValueObject\SilverstripeSetList;
 use Rector\Config\RectorConfig;
 
-return RectorConfig::configure()
-    ->withSets([
-        SilverstripeSetList::WITH_SILVERSTRIPE_API,
-        SilverstripeSetList::WITH_RECTOR_SERVICES,
-    ]);
+return RectorConfig::configure();

--- a/e2e/rename-data-extension-subclass/composer.json
+++ b/e2e/rename-data-extension-subclass/composer.json
@@ -1,0 +1,24 @@
+{
+  "name": "cambis/silverstripe-rector-rename-data-extension-subclass",
+  "type": "silverstripe-vendormodule",
+  "description": "",
+  "require": {
+    "php": "^8.1",
+    "silverstripe/framework": "^5.3"
+  },
+  "require-dev": {
+    "cambis/silverstripe-rector": "dev-main"
+  },
+  "repositories": [
+    {
+      "type": "path",
+      "url": "../../"
+    }
+  ],
+  "config": {
+    "allow-plugins": {
+      "composer/installers": true,
+      "silverstripe/vendor-plugin": true
+    }
+  }
+}

--- a/e2e/rename-data-extension-subclass/expected-output-53.txt
+++ b/e2e/rename-data-extension-subclass/expected-output-53.txt
@@ -1,0 +1,19 @@
+{
+    "totals": {
+        "changed_files": 1,
+        "errors": 0
+    },
+    "file_diffs": [
+        {
+            "file": "src/Model/Extension/BasicExtension.php",
+            "diff": "--- Original\n+++ New\n@@ -4,6 +4,9 @@\n \n use SilverStripe\\ORM\\DataExtension;\n \n-final class BasicExtension extends DataExtension\n+/**\n+ * @extends \\SilverStripe\\Core\\Extension<static>\n+ */\n+final class BasicExtension extends \\SilverStripe\\Core\\Extension\n {\n }\n",
+            "applied_rectors": [
+                "Cambis\\SilverstripeRector\\Silverstripe52\\Rector\\Class_\\AddExtendsAnnotationToExtensionRector",
+                "Rector\\Renaming\\Rector\\Name\\RenameClassRector"
+            ]
+        }
+    ],
+    "changed_files": [
+        "src/Model/Extension/BasicExtension.php"
+    ]
+}

--- a/e2e/rename-data-extension-subclass/rector-53.php
+++ b/e2e/rename-data-extension-subclass/rector-53.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Cambis\SilverstripeRector\Set\ValueObject\SilverstripeLevelSetList;
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/src',
+    ])
+    ->withSets([
+        SilverstripeLevelSetList::UP_TO_SILVERSTRIPE_53,
+    ]);

--- a/e2e/rename-data-extension-subclass/src/Model/Extension/BasicExtension.php
+++ b/e2e/rename-data-extension-subclass/src/Model/Extension/BasicExtension.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Model\Extension;
+
+use SilverStripe\ORM\DataExtension;
+
+final class BasicExtension extends DataExtension
+{
+}

--- a/rules/Silverstripe413/Rector/Class_/CompleteDynamicInjectablePropertiesRector.php
+++ b/rules/Silverstripe413/Rector/Class_/CompleteDynamicInjectablePropertiesRector.php
@@ -4,6 +4,7 @@ namespace Cambis\SilverstripeRector\Silverstripe413\Rector\Class_;
 
 use Cambis\Silverstan\TypeResolver\TypeResolver;
 use Cambis\SilverstripeRector\Rector\AbstractAPIAwareRector;
+use Cambis\SilverstripeRector\Set\ValueObject\SilverstripeSetList;
 use Cambis\SilverstripeRector\ValueObject\SilverstripeConstants;
 use Override;
 use PhpParser\Node;
@@ -12,6 +13,7 @@ use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ObjectType;
 use Rector\CodeQuality\NodeFactory\MissingPropertiesFactory;
+use Rector\Contract\DependencyInjection\RelatedConfigInterface;
 use Rector\NodeAnalyzer\ClassAnalyzer;
 use Rector\NodeAnalyzer\PropertyPresenceChecker;
 use Rector\PostRector\ValueObject\PropertyMetadata;
@@ -22,7 +24,7 @@ use function array_keys;
 /**
  * @see Cambis\SilverstripeRector\Tests\Silverstripe413\Rector\Class_\CompleteDynamicInjectablePropertiesRector\CompleteDynamicInjectablePropertiesRectorTest
  */
-final class CompleteDynamicInjectablePropertiesRector extends AbstractAPIAwareRector
+final class CompleteDynamicInjectablePropertiesRector extends AbstractAPIAwareRector implements RelatedConfigInterface
 {
     public function __construct(
         private readonly ClassAnalyzer $classAnalyzer,
@@ -100,6 +102,12 @@ CODE_SAMPLE
         $node->stmts = [...$newProperties, ...$node->stmts];
 
         return $node;
+    }
+
+    #[Override]
+    public static function getConfigFile(): string
+    {
+        return SilverstripeSetList::WITH_RECTOR_SERVICES;
     }
 
     private function shouldSkipClass(Class_ $class): bool

--- a/src/Rector/Class_/AbstractAddAnnotationsRector.php
+++ b/src/Rector/Class_/AbstractAddAnnotationsRector.php
@@ -9,6 +9,7 @@ use Cambis\SilverstripeRector\NodeResolver\DataRecordResolver;
 use Cambis\SilverstripeRector\PhpDoc\AnnotationUpdater;
 use Cambis\SilverstripeRector\PhpDoc\PhpDocHelper;
 use Cambis\SilverstripeRector\Rector\AbstractAPIAwareRector;
+use Cambis\SilverstripeRector\Set\ValueObject\SilverstripeSetList;
 use Cambis\SilverstripeRector\TypeResolver\Contract\ConfigurationPropertyTypeResolverInterface;
 use Override;
 use PhpParser\Node;
@@ -24,11 +25,12 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\TemplateTagValueNode;
 use PHPStan\Reflection\ReflectionProvider;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
+use Rector\Contract\DependencyInjection\RelatedConfigInterface;
 use Rector\Exception\NotImplementedYetException;
 use Rector\NodeAnalyzer\ClassAnalyzer;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 
-abstract class AbstractAddAnnotationsRector extends AbstractAPIAwareRector
+abstract class AbstractAddAnnotationsRector extends AbstractAPIAwareRector implements RelatedConfigInterface
 {
     /**
      * @var array<class-string<PhpDocTagValueNode>, string>
@@ -100,6 +102,12 @@ abstract class AbstractAddAnnotationsRector extends AbstractAPIAwareRector
         $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
 
         return $node;
+    }
+
+    #[Override]
+    public static function getConfigFile(): string
+    {
+        return SilverstripeSetList::WITH_RECTOR_SERVICES;
     }
 
     /**

--- a/tests/rules/Silverstripe413/Rector/Class_/AddBelongsManyManyMethodAnnotationsToDataObjectRector/config/configured_rule.php
+++ b/tests/rules/Silverstripe413/Rector/Class_/AddBelongsManyManyMethodAnnotationsToDataObjectRector/config/configured_rule.php
@@ -2,14 +2,12 @@
 
 declare(strict_types=1);
 
-use Cambis\SilverstripeRector\Set\ValueObject\SilverstripeSetList;
 use Cambis\SilverstripeRector\Silverstripe413\Rector\Class_\AddBelongsManyManyMethodAnnotationsToDataObjectRector;
 use Cambis\SilverstripeRector\Silverstripe413\TypeResolver\ConfigurationPropertyTypeResolver;
 use Cambis\SilverstripeRector\TypeResolver\Contract\ConfigurationPropertyTypeResolverInterface;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(SilverstripeSetList::WITH_RECTOR_SERVICES);
     $rectorConfig->rule(AddBelongsManyManyMethodAnnotationsToDataObjectRector::class);
     $rectorConfig->singleton(ConfigurationPropertyTypeResolverInterface::class, ConfigurationPropertyTypeResolver::class);
 };

--- a/tests/rules/Silverstripe413/Rector/Class_/AddBelongsToPropertyAndMethodAnnotationsToDataObjectRector/config/configured_rule.php
+++ b/tests/rules/Silverstripe413/Rector/Class_/AddBelongsToPropertyAndMethodAnnotationsToDataObjectRector/config/configured_rule.php
@@ -2,14 +2,12 @@
 
 declare(strict_types=1);
 
-use Cambis\SilverstripeRector\Set\ValueObject\SilverstripeSetList;
 use Cambis\SilverstripeRector\Silverstripe413\Rector\Class_\AddBelongsToPropertyAndMethodAnnotationsToDataObjectRector;
 use Cambis\SilverstripeRector\Silverstripe413\TypeResolver\ConfigurationPropertyTypeResolver;
 use Cambis\SilverstripeRector\TypeResolver\Contract\ConfigurationPropertyTypeResolverInterface;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(SilverstripeSetList::WITH_RECTOR_SERVICES);
     $rectorConfig->rule(AddBelongsToPropertyAndMethodAnnotationsToDataObjectRector::class);
     $rectorConfig->singleton(ConfigurationPropertyTypeResolverInterface::class, ConfigurationPropertyTypeResolver::class);
 };

--- a/tests/rules/Silverstripe413/Rector/Class_/AddDBFieldPropertyAnnotationsToDataObjectRector/config/configured_rule.php
+++ b/tests/rules/Silverstripe413/Rector/Class_/AddDBFieldPropertyAnnotationsToDataObjectRector/config/configured_rule.php
@@ -2,14 +2,12 @@
 
 declare(strict_types=1);
 
-use Cambis\SilverstripeRector\Set\ValueObject\SilverstripeSetList;
 use Cambis\SilverstripeRector\Silverstripe413\Rector\Class_\AddDBFieldPropertyAnnotationsToDataObjectRector;
 use Cambis\SilverstripeRector\Silverstripe413\TypeResolver\ConfigurationPropertyTypeResolver;
 use Cambis\SilverstripeRector\TypeResolver\Contract\ConfigurationPropertyTypeResolverInterface;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(SilverstripeSetList::WITH_RECTOR_SERVICES);
     $rectorConfig->rule(AddDBFieldPropertyAnnotationsToDataObjectRector::class);
     $rectorConfig->singleton(ConfigurationPropertyTypeResolverInterface::class, ConfigurationPropertyTypeResolver::class);
 };

--- a/tests/rules/Silverstripe413/Rector/Class_/AddExtensionMixinAnnotationsToExtensibleRector/config/configured_rule.php
+++ b/tests/rules/Silverstripe413/Rector/Class_/AddExtensionMixinAnnotationsToExtensibleRector/config/configured_rule.php
@@ -2,14 +2,12 @@
 
 declare(strict_types=1);
 
-use Cambis\SilverstripeRector\Set\ValueObject\SilverstripeSetList;
 use Cambis\SilverstripeRector\Silverstripe413\Rector\Class_\AddExtensionMixinAnnotationsToExtensibleRector;
 use Cambis\SilverstripeRector\Silverstripe413\TypeResolver\ConfigurationPropertyTypeResolver;
 use Cambis\SilverstripeRector\TypeResolver\Contract\ConfigurationPropertyTypeResolverInterface;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(SilverstripeSetList::WITH_RECTOR_SERVICES);
     $rectorConfig->rule(AddExtensionMixinAnnotationsToExtensibleRector::class);
     $rectorConfig->singleton(ConfigurationPropertyTypeResolverInterface::class, ConfigurationPropertyTypeResolver::class);
 };

--- a/tests/rules/Silverstripe413/Rector/Class_/AddGetOwnerMethodAnnotationToExtensionRector/config/configured_rule.php
+++ b/tests/rules/Silverstripe413/Rector/Class_/AddGetOwnerMethodAnnotationToExtensionRector/config/configured_rule.php
@@ -2,14 +2,12 @@
 
 declare(strict_types=1);
 
-use Cambis\SilverstripeRector\Set\ValueObject\SilverstripeSetList;
 use Cambis\SilverstripeRector\Silverstripe413\Rector\Class_\AddGetOwnerMethodAnnotationToExtensionRector;
 use Cambis\SilverstripeRector\Silverstripe413\TypeResolver\ConfigurationPropertyTypeResolver;
 use Cambis\SilverstripeRector\TypeResolver\Contract\ConfigurationPropertyTypeResolverInterface;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(SilverstripeSetList::WITH_RECTOR_SERVICES);
     $rectorConfig->rule(AddGetOwnerMethodAnnotationToExtensionRector::class);
     $rectorConfig->singleton(ConfigurationPropertyTypeResolverInterface::class, ConfigurationPropertyTypeResolver::class);
 };

--- a/tests/rules/Silverstripe413/Rector/Class_/AddHasManyMethodAnnotationsToDataObjectRector/config/configured_rule.php
+++ b/tests/rules/Silverstripe413/Rector/Class_/AddHasManyMethodAnnotationsToDataObjectRector/config/configured_rule.php
@@ -2,14 +2,12 @@
 
 declare(strict_types=1);
 
-use Cambis\SilverstripeRector\Set\ValueObject\SilverstripeSetList;
 use Cambis\SilverstripeRector\Silverstripe413\Rector\Class_\AddHasManyMethodAnnotationsToDataObjectRector;
 use Cambis\SilverstripeRector\Silverstripe413\TypeResolver\ConfigurationPropertyTypeResolver;
 use Cambis\SilverstripeRector\TypeResolver\Contract\ConfigurationPropertyTypeResolverInterface;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(SilverstripeSetList::WITH_RECTOR_SERVICES);
     $rectorConfig->rule(AddHasManyMethodAnnotationsToDataObjectRector::class);
     $rectorConfig->singleton(ConfigurationPropertyTypeResolverInterface::class, ConfigurationPropertyTypeResolver::class);
 };

--- a/tests/rules/Silverstripe413/Rector/Class_/AddHasOnePropertyAndMethodAnnotationsToDataObjectRector/config/configured_rule.php
+++ b/tests/rules/Silverstripe413/Rector/Class_/AddHasOnePropertyAndMethodAnnotationsToDataObjectRector/config/configured_rule.php
@@ -2,14 +2,12 @@
 
 declare(strict_types=1);
 
-use Cambis\SilverstripeRector\Set\ValueObject\SilverstripeSetList;
 use Cambis\SilverstripeRector\Silverstripe413\Rector\Class_\AddHasOnePropertyAndMethodAnnotationsToDataObjectRector;
 use Cambis\SilverstripeRector\Silverstripe413\TypeResolver\ConfigurationPropertyTypeResolver;
 use Cambis\SilverstripeRector\TypeResolver\Contract\ConfigurationPropertyTypeResolverInterface;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(SilverstripeSetList::WITH_RECTOR_SERVICES);
     $rectorConfig->rule(AddHasOnePropertyAndMethodAnnotationsToDataObjectRector::class);
     $rectorConfig->singleton(ConfigurationPropertyTypeResolverInterface::class, ConfigurationPropertyTypeResolver::class);
 };

--- a/tests/rules/Silverstripe413/Rector/Class_/AddManyManyMethodAnnotationsToDataObjectRector/config/configured_rule.php
+++ b/tests/rules/Silverstripe413/Rector/Class_/AddManyManyMethodAnnotationsToDataObjectRector/config/configured_rule.php
@@ -2,14 +2,12 @@
 
 declare(strict_types=1);
 
-use Cambis\SilverstripeRector\Set\ValueObject\SilverstripeSetList;
 use Cambis\SilverstripeRector\Silverstripe413\Rector\Class_\AddManyManyMethodAnnotationsToDataObjectRector;
 use Cambis\SilverstripeRector\Silverstripe413\TypeResolver\ConfigurationPropertyTypeResolver;
 use Cambis\SilverstripeRector\TypeResolver\Contract\ConfigurationPropertyTypeResolverInterface;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(SilverstripeSetList::WITH_RECTOR_SERVICES);
     $rectorConfig->rule(AddManyManyMethodAnnotationsToDataObjectRector::class);
     $rectorConfig->singleton(ConfigurationPropertyTypeResolverInterface::class, ConfigurationPropertyTypeResolver::class);
 };

--- a/tests/rules/Silverstripe413/Rector/Class_/CompleteDynamicInjectablePropertiesRector/config/configured_rule.php
+++ b/tests/rules/Silverstripe413/Rector/Class_/CompleteDynamicInjectablePropertiesRector/config/configured_rule.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use Cambis\SilverstripeRector\Set\ValueObject\SilverstripeSetList;
 use Cambis\SilverstripeRector\Silverstripe413\Rector\Class_\CompleteDynamicInjectablePropertiesRector;
 use Cambis\SilverstripeRector\Silverstripe413\TypeResolver\ConfigurationPropertyTypeResolver;
 use Cambis\SilverstripeRector\TypeResolver\Contract\ConfigurationPropertyTypeResolverInterface;
@@ -10,7 +9,6 @@ use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\SetList;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(SilverstripeSetList::WITH_RECTOR_SERVICES);
     $rectorConfig->importShortClasses();
 
     $rectorConfig->sets([

--- a/tests/rules/Silverstripe52/Rector/Class_/AddBelongsManyManyMethodAnnotationsToDataObjectRector/config/configured_rule.php
+++ b/tests/rules/Silverstripe52/Rector/Class_/AddBelongsManyManyMethodAnnotationsToDataObjectRector/config/configured_rule.php
@@ -2,14 +2,12 @@
 
 declare(strict_types=1);
 
-use Cambis\SilverstripeRector\Set\ValueObject\SilverstripeSetList;
 use Cambis\SilverstripeRector\Silverstripe52\Rector\Class_\AddBelongsManyManyMethodAnnotationsToDataObjectRector;
 use Cambis\SilverstripeRector\Silverstripe52\TypeResolver\ConfigurationPropertyTypeResolver;
 use Cambis\SilverstripeRector\TypeResolver\Contract\ConfigurationPropertyTypeResolverInterface;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(SilverstripeSetList::WITH_RECTOR_SERVICES);
     $rectorConfig->rule(AddBelongsManyManyMethodAnnotationsToDataObjectRector::class);
     $rectorConfig->singleton(ConfigurationPropertyTypeResolverInterface::class, ConfigurationPropertyTypeResolver::class);
 };

--- a/tests/rules/Silverstripe52/Rector/Class_/AddExtendsAnnotationToContentControllerRector/config/configured_rule.php
+++ b/tests/rules/Silverstripe52/Rector/Class_/AddExtendsAnnotationToContentControllerRector/config/configured_rule.php
@@ -2,14 +2,12 @@
 
 declare(strict_types=1);
 
-use Cambis\SilverstripeRector\Set\ValueObject\SilverstripeSetList;
 use Cambis\SilverstripeRector\Silverstripe52\Rector\Class_\AddExtendsAnnotationToContentControllerRector;
 use Cambis\SilverstripeRector\Silverstripe52\TypeResolver\ConfigurationPropertyTypeResolver;
 use Cambis\SilverstripeRector\TypeResolver\Contract\ConfigurationPropertyTypeResolverInterface;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(SilverstripeSetList::WITH_RECTOR_SERVICES);
     $rectorConfig->rule(AddExtendsAnnotationToContentControllerRector::class);
     $rectorConfig->singleton(ConfigurationPropertyTypeResolverInterface::class, ConfigurationPropertyTypeResolver::class);
 };

--- a/tests/rules/Silverstripe52/Rector/Class_/AddExtendsAnnotationToExtensionRector/config/configured_rule.php
+++ b/tests/rules/Silverstripe52/Rector/Class_/AddExtendsAnnotationToExtensionRector/config/configured_rule.php
@@ -2,14 +2,12 @@
 
 declare(strict_types=1);
 
-use Cambis\SilverstripeRector\Set\ValueObject\SilverstripeSetList;
 use Cambis\SilverstripeRector\Silverstripe52\Rector\Class_\AddExtendsAnnotationToExtensionRector;
 use Cambis\SilverstripeRector\Silverstripe52\TypeResolver\ConfigurationPropertyTypeResolver;
 use Cambis\SilverstripeRector\TypeResolver\Contract\ConfigurationPropertyTypeResolverInterface;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(SilverstripeSetList::WITH_RECTOR_SERVICES);
     $rectorConfig->rule(AddExtendsAnnotationToExtensionRector::class);
     $rectorConfig->singleton(ConfigurationPropertyTypeResolverInterface::class, ConfigurationPropertyTypeResolver::class);
 };

--- a/tests/rules/Silverstripe52/Rector/Class_/AddHasManyMethodAnnotationsToDataObjectRector/config/configured_rule.php
+++ b/tests/rules/Silverstripe52/Rector/Class_/AddHasManyMethodAnnotationsToDataObjectRector/config/configured_rule.php
@@ -2,14 +2,12 @@
 
 declare(strict_types=1);
 
-use Cambis\SilverstripeRector\Set\ValueObject\SilverstripeSetList;
 use Cambis\SilverstripeRector\Silverstripe52\Rector\Class_\AddHasManyMethodAnnotationsToDataObjectRector;
 use Cambis\SilverstripeRector\Silverstripe52\TypeResolver\ConfigurationPropertyTypeResolver;
 use Cambis\SilverstripeRector\TypeResolver\Contract\ConfigurationPropertyTypeResolverInterface;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(SilverstripeSetList::WITH_RECTOR_SERVICES);
     $rectorConfig->rule(AddHasManyMethodAnnotationsToDataObjectRector::class);
     $rectorConfig->singleton(ConfigurationPropertyTypeResolverInterface::class, ConfigurationPropertyTypeResolver::class);
 };

--- a/tests/rules/Silverstripe52/Rector/Class_/AddManyManyMethodAnnotationsToDataObjectRector/config/configured_rule.php
+++ b/tests/rules/Silverstripe52/Rector/Class_/AddManyManyMethodAnnotationsToDataObjectRector/config/configured_rule.php
@@ -2,14 +2,12 @@
 
 declare(strict_types=1);
 
-use Cambis\SilverstripeRector\Set\ValueObject\SilverstripeSetList;
 use Cambis\SilverstripeRector\Silverstripe52\Rector\Class_\AddManyManyMethodAnnotationsToDataObjectRector;
 use Cambis\SilverstripeRector\Silverstripe52\TypeResolver\ConfigurationPropertyTypeResolver;
 use Cambis\SilverstripeRector\TypeResolver\Contract\ConfigurationPropertyTypeResolverInterface;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(SilverstripeSetList::WITH_RECTOR_SERVICES);
     $rectorConfig->rule(AddManyManyMethodAnnotationsToDataObjectRector::class);
     $rectorConfig->singleton(ConfigurationPropertyTypeResolverInterface::class, ConfigurationPropertyTypeResolver::class);
 };

--- a/tests/rules/Silverstripe52/Rector/Class_/RemoveGetOwnerMethodAnnotationFromExtensionsRector/config/configured_rule.php
+++ b/tests/rules/Silverstripe52/Rector/Class_/RemoveGetOwnerMethodAnnotationFromExtensionsRector/config/configured_rule.php
@@ -2,11 +2,9 @@
 
 declare(strict_types=1);
 
-use Cambis\SilverstripeRector\Set\ValueObject\SilverstripeSetList;
 use Cambis\SilverstripeRector\Silverstripe52\Rector\Class_\RemoveGetOwnerMethodAnnotationFromExtensionsRector;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(SilverstripeSetList::WITH_RECTOR_SERVICES);
     $rectorConfig->rule(RemoveGetOwnerMethodAnnotationFromExtensionsRector::class);
 };

--- a/tests/src/Set/Silverstripe413/config/configured_rule.php
+++ b/tests/src/Set/Silverstripe413/config/configured_rule.php
@@ -3,12 +3,10 @@
 declare(strict_types=1);
 
 use Cambis\SilverstripeRector\Set\ValueObject\SilverstripeLevelSetList;
-use Cambis\SilverstripeRector\Set\ValueObject\SilverstripeSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([
-        SilverstripeSetList::WITH_RECTOR_SERVICES,
         SilverstripeLevelSetList::UP_TO_SILVERSTRIPE_413,
     ]);
 };

--- a/tests/src/Set/Silverstripe52/config/configured_rule.php
+++ b/tests/src/Set/Silverstripe52/config/configured_rule.php
@@ -3,12 +3,10 @@
 declare(strict_types=1);
 
 use Cambis\SilverstripeRector\Set\ValueObject\SilverstripeLevelSetList;
-use Cambis\SilverstripeRector\Set\ValueObject\SilverstripeSetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([
-        SilverstripeSetList::WITH_RECTOR_SERVICES,
         SilverstripeLevelSetList::UP_TO_SILVERSTRIPE_52,
     ]);
 };


### PR DESCRIPTION
## Description ✍️

- Use RelatedConfigInterface to provide required services for selected rectors
- Remove now duplicated imports of WITH_RECTOR_SERVICES set

## DoD checklist ✅

- [x] I have performed a self-review of my code
- [x] My code adheres to the [coding standards](https://github.com/Cambis/silverstripe-rector/blob/main/CONTRIBUTING.md#coding-standards-️)
- [x] My commit messages adhere to the [commit standards](https://github.com/Cambis/silverstripe-rector/blob/main/CONTRIBUTING.md#commit-standards-️).
- [x] My code has been [tested](https://github.com/Cambis/silverstripe-rector/blob/main/CONTRIBUTING.md#testing-).
- [x] I have added a [changeset](https://github.com/Cambis/silverstripe-rector/blob/main/CONTRIBUTING.md#making-a-pull-request-).
