### PR TITLE
Add gorriecoe link migration rectors

### DIFF
--- a/.changeset/eleven-nails-glow.md
+++ b/.changeset/eleven-nails-glow.md
@@ -1,0 +1,5 @@
+---
+"@cambis/silverstripe-rector": minor
+---
+
+Add rectors to migrate gorriecoe link to silverstripe linkfield

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,8 +45,10 @@ jobs:
             cms-version: 5.3
           - directory: e2e/rename-data-extension-subclass
             php-version: 8.1
+            framework-version: 5.3
           - directory: e2e/gorriecoe-link-to-silverstripe-linkfield
             php-version: 8.1
+            framework-version: 5.3
     steps:
       # Build source code
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,7 +45,8 @@ jobs:
             cms-version: 5.3
           - directory: e2e/rename-data-extension-subclass
             php-version: 8.1
-            framework-version: 5.3
+          - directory: e2e/gorriecoe-link-to-silverstripe-linkfield
+            php-version: 8.1
     steps:
       # Build source code
       - uses: actions/checkout@v4

--- a/config/rector-services.php
+++ b/config/rector-services.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Cambis\Silverstan\Autoloader\Autoloader;
 use Cambis\Silverstan\ClassManifest\ClassManifest;
+use Cambis\Silverstan\ConfigurationResolver\ConfigurationResolver;
 use Cambis\Silverstan\TypeResolver\TypeResolver;
 use Cambis\SilverstripeRector\AnnotationComparator\AnnotationComparator;
 use Cambis\SilverstripeRector\AnnotationComparator\AnnotationComparator\ExtendsAnnotationComparator;
@@ -34,6 +35,7 @@ return static function (RectorConfig $rectorConfig): void {
     $silverstanServices = [
         Autoloader::class,
         ClassManifest::class,
+        ConfigurationResolver::class,
         TypeResolver::class,
     ];
 

--- a/config/set/gorriecoe-link-to-silverstripe-linkfield.php
+++ b/config/set/gorriecoe-link-to-silverstripe-linkfield.php
@@ -1,0 +1,19 @@
+<?php
+
+use Cambis\SilverstripeRector\LinkField\Rector\Class_\GorriecoeLinkToSilverstripeLinkRector;
+use Cambis\SilverstripeRector\LinkField\Rector\StaticCall\GorriecoeLinkFieldToSilverstripeLinkFieldRector;
+use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+
+return RectorConfig::configure()
+    ->withRules([
+        GorriecoeLinkToSilverstripeLinkRector::class,
+        GorriecoeLinkFieldToSilverstripeLinkFieldRector::class,
+    ])
+    ->withConfiguredRule(
+        RenameClassRector::class,
+        [
+            'gorriecoe\Link\Models\Link' => 'SilverStripe\LinkField\Models\Link',
+            'gorriecoe\LinkField\LinkField' => 'SilverStripe\LinkField\Form\LinkField',
+        ]
+    );

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,10 +1,12 @@
-# 20 Rules Overview
+# 22 Rules Overview
 
 <br>
 
 ## Categories
 
 - [CodeQuality](#codequality) (3)
+
+- [LinkField](#linkfield) (2)
 
 - [Silverstripe413](#silverstripe413) (9)
 
@@ -60,6 +62,60 @@ Transforms static property fetch into `$this->config->get()`.
 -        return self::$singular_name;
 +        return $this->config()->get('singular_name');
      }
+ }
+```
+
+<br>
+
+## LinkField
+
+### GorriecoeLinkFieldToSilverstripeLinkFieldRector
+
+Migrate `gorriecoe\LinkField\LinkField` to `SilverStripe\LinkField\Form\LinkField`.
+
+- class: [`Cambis\SilverstripeRector\LinkField\Rector\StaticCall\GorriecoeLinkFieldToSilverstripeLinkFieldRector`](../rules/LinkField/Rector/StaticCall/GorriecoeLinkFieldToSilverstripeLinkFieldRector.php)
+
+```diff
+-\gorriecoe\LinkField\LinkField::create('Link', 'Link', $this, ['types' => ['SiteTree']]);
++\SilverStripe\LinkField\Form\LinkField::create('Link', 'Link')
++    ->setAllowedTypes([\SilverStripe\LinkField\Models\SiteTreeLink::class]);
+```
+
+<br>
+
+### GorriecoeLinkToSilverstripeLinkRector
+
+Migrate `gorriecoe\Link\Models\Link` configuration to `SilverStripe\LinkField\Models\Link` configuration.
+
+- class: [`Cambis\SilverstripeRector\LinkField\Rector\Class_\GorriecoeLinkToSilverstripeLinkRector`](../rules/LinkField/Rector/Class_/GorriecoeLinkToSilverstripeLinkRector.php)
+
+```diff
+ class Foo extends \SilverStripe\ORM\DataObject
+ {
+     private static array $has_one = [
+-        'HasOneLink' => \gorriecoe\Link\Models\Link::class,
++        'HasOneLink' => \SilverStripe\LinkField\Models\Link::class,
+     ];
+
+     private static array $has_many = [
+-        'HasManyLinks' => \gorriecoe\Link\Models\Link::class,
++        'HasManyLinks' => \SilverStripe\LinkField\Models\Link::class . '.Owner',
++        'ManyManyLinks' => \SilverStripe\LinkField\Models\Link::class . '.Owner',
+     ];
+
+-    private static array $many_many = [
+-        'ManyManyLinks' => \gorriecoe\Link\Models\Link::class,
+-    ];
+-
+-    private static array $many_many_extraFields = [
+-        'ManyManyLinks' => [
+-            'Sort' => 'Int',
+-        ],
++    private static array $owns = [
++        'HasOneLink',
++        'HasManyLinks',
++        'ManyManyLinks',
+     ];
  }
 ```
 
@@ -151,8 +207,6 @@ Add missing dynamic annotations.
 ### AddGetOwnerMethodAnnotationToExtensionRector
 
 Add missing dynamic annotations.
-
-:wrench: **configure it!**
 
 - class: [`Cambis\SilverstripeRector\Silverstripe413\Rector\Class_\AddGetOwnerMethodAnnotationToExtensionRector`](../rules/Silverstripe413/Rector/Class_/AddGetOwnerMethodAnnotationToExtensionRector.php)
 
@@ -326,8 +380,6 @@ Add missing dynamic annotations.
 ### AddExtendsAnnotationToExtensionRector
 
 Add missing dynamic annotations.
-
-:wrench: **configure it!**
 
 - class: [`Cambis\SilverstripeRector\Silverstripe52\Rector\Class_\AddExtendsAnnotationToExtensionRector`](../rules/Silverstripe52/Rector/Class_/AddExtendsAnnotationToExtensionRector.php)
 

--- a/e2e/gorriecoe-link-to-silverstripe-linkfield/app/src/Model/Block.php
+++ b/e2e/gorriecoe-link-to-silverstripe-linkfield/app/src/Model/Block.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Model;
+
+use SilverStripe\ORM\DataObject;
+
+class Block extends DataObject
+{
+    private static string $table_name = 'Block';
+
+    private static array $db = [
+        'Title' => 'Varchar(255)',
+    ];
+}

--- a/e2e/gorriecoe-link-to-silverstripe-linkfield/app/src/Model/Block/LinkBlock.php
+++ b/e2e/gorriecoe-link-to-silverstripe-linkfield/app/src/Model/Block/LinkBlock.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Model\Block;
+
+use App\Model\Block;
+use gorriecoe\Link\Models\Link;
+use gorriecoe\LinkField\LinkField;
+use SilverStripe\Forms\FieldList;
+
+final class LinkBlock extends Block
+{
+    /**
+     * @var array{types: string[], title_display: bool}
+     */
+    private const LINK_CONFIG = [
+        'types' => ['URL', 'SiteTree'],
+        'title_display' => false,
+    ];
+
+    private static string $table_name = 'LinkBlock';
+
+    private static array $has_one = [
+        'Link' => Link::class,
+    ];
+
+    public function getCMSFields(): FieldList
+    {
+        return parent::getCMSFields()
+            ->removeByName(['LinkID'])
+            ->addFieldToTab(
+                'Root.Main',
+                LinkField::create('Link', 'Link', $this, self::LINK_CONFIG),
+            );
+    }
+}

--- a/e2e/gorriecoe-link-to-silverstripe-linkfield/app/src/Model/Block/LinkCollectionBlock.php
+++ b/e2e/gorriecoe-link-to-silverstripe-linkfield/app/src/Model/Block/LinkCollectionBlock.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Model\Block;
+
+use App\Model\Block;
+use gorriecoe\Link\Models\Link;
+use gorriecoe\LinkField\LinkField;
+use SilverStripe\Forms\FieldList;
+
+final class LinkCollectionBlock extends Block
+{
+    private static string $table_name = 'LinkCollectionBlock';
+
+    private static array $many_many = [
+        'Links' => Link::class,
+    ];
+
+    private static array $many_many_extraFields = [
+        'Links' => [
+            'Sort' => 'Int',
+        ],
+    ];
+
+    public function getCMSFields(): FieldList
+    {
+        return parent::getCMSFields()
+            ->removeByName(['Links'])
+            ->addFieldToTab(
+                'Root.Main',
+                LinkField::create('Links', 'Links', $this, [
+                    'types' => ['URL', 'SiteTree'],
+                ]),
+            );
+    }
+}

--- a/e2e/gorriecoe-link-to-silverstripe-linkfield/app/src/Page.php
+++ b/e2e/gorriecoe-link-to-silverstripe-linkfield/app/src/Page.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace {
+
+    use App\Model\Block;
+    use SilverStripe\CMS\Model\SiteTree;
+
+    class Page extends SiteTree
+    {
+        private static array $has_many = [
+            'Blocks' => Block::class,
+        ];
+    }
+}

--- a/e2e/gorriecoe-link-to-silverstripe-linkfield/app/src/PageController.php
+++ b/e2e/gorriecoe-link-to-silverstripe-linkfield/app/src/PageController.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace {
+
+    use SilverStripe\CMS\Controllers\ContentController;
+
+    class PageController extends ContentController
+    {
+    }
+}

--- a/e2e/gorriecoe-link-to-silverstripe-linkfield/composer.json
+++ b/e2e/gorriecoe-link-to-silverstripe-linkfield/composer.json
@@ -1,0 +1,26 @@
+{
+  "name": "cambis/silverstripe-rector-gorriecoe-link-to-silverstripe-linkfield",
+  "type": "project",
+  "description": "",
+  "require": {
+    "php": "^8.1",
+    "silverstripe/cms": "^5.3",
+    "silverstripe/framework": "^5.3",
+    "silverstripe/linkfield": "^4.0"
+  },
+  "require-dev": {
+    "cambis/silverstripe-rector": "dev-main"
+  },
+  "repositories": [
+    {
+      "type": "path",
+      "url": "../../"
+    }
+  ],
+  "config": {
+    "allow-plugins": {
+      "composer/installers": true,
+      "silverstripe/vendor-plugin": true
+    }
+  }
+}

--- a/e2e/gorriecoe-link-to-silverstripe-linkfield/expected-output-53.txt
+++ b/e2e/gorriecoe-link-to-silverstripe-linkfield/expected-output-53.txt
@@ -1,0 +1,28 @@
+{
+    "totals": {
+        "changed_files": 2,
+        "errors": 0
+    },
+    "file_diffs": [
+        {
+            "file": "app/src/Model/Block/LinkBlock.php",
+            "diff": "--- Original\n+++ New\n@@ -2,9 +2,11 @@\n \n namespace App\\Model\\Block;\n \n+use SilverStripe\\LinkField\\Models\\Link;\n+use SilverStripe\\LinkField\\Form\\LinkField;\n+use SilverStripe\\LinkField\\Models\\ExternalLink;\n+use SilverStripe\\LinkField\\Models\\SiteTreeLink;\n use App\\Model\\Block;\n-use gorriecoe\\Link\\Models\\Link;\n-use gorriecoe\\LinkField\\LinkField;\n use SilverStripe\\Forms\\FieldList;\n \n final class LinkBlock extends Block\n@@ -22,6 +24,7 @@\n     private static array $has_one = [\n         'Link' => Link::class,\n     ];\n+    private static array $owns = ['Link'];\n \n     public function getCMSFields(): FieldList\n     {\n@@ -29,7 +32,7 @@\n             ->removeByName(['LinkID'])\n             ->addFieldToTab(\n                 'Root.Main',\n-                LinkField::create('Link', 'Link', $this, self::LINK_CONFIG),\n+                LinkField::create('Link', 'Link')->setAllowedTypes([ExternalLink::class, SiteTreeLink::class])->setExcludeLinkTextField(false),\n             );\n     }\n }\n",
+            "applied_rectors": [
+                "Cambis\\SilverstripeRector\\LinkField\\Rector\\Class_\\GorriecoeLinkToSilverstripeLinkRector",
+                "Cambis\\SilverstripeRector\\LinkField\\Rector\\StaticCall\\GorriecoeLinkFieldToSilverstripeLinkFieldRector"
+            ]
+        },
+        {
+            "file": "app/src/Model/Block/LinkCollectionBlock.php",
+            "diff": "--- Original\n+++ New\n@@ -2,9 +2,11 @@\n \n namespace App\\Model\\Block;\n \n+use SilverStripe\\LinkField\\Models\\Link;\n+use SilverStripe\\LinkField\\Form\\LinkField;\n+use SilverStripe\\LinkField\\Models\\ExternalLink;\n+use SilverStripe\\LinkField\\Models\\SiteTreeLink;\n use App\\Model\\Block;\n-use gorriecoe\\Link\\Models\\Link;\n-use gorriecoe\\LinkField\\LinkField;\n use SilverStripe\\Forms\\FieldList;\n \n final class LinkCollectionBlock extends Block\n@@ -11,15 +13,9 @@\n {\n     private static string $table_name = 'LinkCollectionBlock';\n \n-    private static array $many_many = [\n-        'Links' => Link::class,\n-    ];\n+    private static array $owns = ['Links'];\n \n-    private static array $many_many_extraFields = [\n-        'Links' => [\n-            'Sort' => 'Int',\n-        ],\n-    ];\n+    private static array $has_many = ['Links' => Link::class . '.Owner'];\n \n     public function getCMSFields(): FieldList\n     {\n@@ -27,9 +23,7 @@\n             ->removeByName(['Links'])\n             ->addFieldToTab(\n                 'Root.Main',\n-                LinkField::create('Links', 'Links', $this, [\n-                    'types' => ['URL', 'SiteTree'],\n-                ]),\n+                LinkField::create('Links', 'Links')->setAllowedTypes([ExternalLink::class, SiteTreeLink::class]),\n             );\n     }\n }\n",
+            "applied_rectors": [
+                "Cambis\\SilverstripeRector\\LinkField\\Rector\\Class_\\GorriecoeLinkToSilverstripeLinkRector",
+                "Cambis\\SilverstripeRector\\LinkField\\Rector\\StaticCall\\GorriecoeLinkFieldToSilverstripeLinkFieldRector"
+            ]
+        }
+    ],
+    "changed_files": [
+        "app/src/Model/Block/LinkBlock.php",
+        "app/src/Model/Block/LinkCollectionBlock.php"
+    ]
+}

--- a/e2e/gorriecoe-link-to-silverstripe-linkfield/rector-53.php
+++ b/e2e/gorriecoe-link-to-silverstripe-linkfield/rector-53.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Cambis\SilverstripeRector\Set\ValueObject\SilverstripeSetList;
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withImportNames(removeUnusedImports: true)
+    ->withPaths([
+        __DIR__ . '/app/src',
+    ])
+    ->withSets([
+        SilverstripeSetList::GORRIECOE_LINK_TO_SILVERSTRIPE_LINKFIELD,
+    ]);

--- a/rules/LinkField/Rector/Class_/GorriecoeLinkToSilverstripeLinkRector.php
+++ b/rules/LinkField/Rector/Class_/GorriecoeLinkToSilverstripeLinkRector.php
@@ -1,0 +1,440 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\SilverstripeRector\LinkField\Rector\Class_;
+
+use Cambis\Silverstan\ConfigurationResolver\ConfigurationResolver;
+use Cambis\SilverstripeRector\NodeAnalyser\ClassAnalyser;
+use Cambis\SilverstripeRector\NodeFactory\PropertyFactory;
+use Cambis\SilverstripeRector\Set\ValueObject\SilverstripeSetList;
+use Cambis\SilverstripeRector\ValueObject\SilverstripeConstants;
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Expr\BinaryOp\Concat;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Property;
+use Rector\Contract\DependencyInjection\RelatedConfigInterface;
+use Rector\PhpParser\Node\Value\ValueResolver;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use function in_array;
+use function is_array;
+use function is_string;
+
+/**
+ * @see \Cambis\SilverstripeRector\Tests\LinkField\Rector\Class_\GorriecoeLinkToSilverstripeLinkRector\GorriecoeLinkToSilverstripeLinkRectorTest
+ */
+final class GorriecoeLinkToSilverstripeLinkRector extends AbstractRector implements RelatedConfigInterface
+{
+    private bool $hasChanged = false;
+
+    public function __construct(
+        private readonly ClassAnalyser $classAnalyser,
+        private readonly ConfigurationResolver $configurationResolver,
+        private readonly PropertyFactory $propertyFactory,
+        private readonly ValueResolver $valueResolver
+    ) {
+    }
+
+    #[Override]
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Migrate `gorriecoe\Link\Models\Link` configuration to `SilverStripe\LinkField\Models\Link` configuration.', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+class Foo extends \SilverStripe\ORM\DataObject
+{
+    private static array $has_one = [
+        'HasOneLink' => \gorriecoe\Link\Models\Link::class,
+    ];
+
+    private static array $has_many = [
+        'HasManyLinks' => \gorriecoe\Link\Models\Link::class,
+    ];
+
+    private static array $many_many = [
+        'ManyManyLinks' => \gorriecoe\Link\Models\Link::class,
+    ];
+
+    private static array $many_many_extraFields = [
+        'ManyManyLinks' => [
+            'Sort' => 'Int',
+        ],
+    ];
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+class Foo extends \SilverStripe\ORM\DataObject
+{
+    private static array $has_one = [
+        'HasOneLink' => \SilverStripe\LinkField\Models\Link::class,
+    ];
+
+    private static array $has_many = [
+        'HasManyLinks' => \SilverStripe\LinkField\Models\Link::class . '.Owner',
+        'ManyManyLinks' => \SilverStripe\LinkField\Models\Link::class . '.Owner',
+    ];
+
+    private static array $owns = [
+        'HasOneLink',
+        'HasManyLinks',
+        'ManyManyLinks',
+    ];
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    #[Override]
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    #[Override]
+    public function refactor(Node $node): ?Node
+    {
+        if (!$this->classAnalyser->isDataObject($node)) {
+            return null;
+        }
+
+        $hasOne = $this->propertyFactory->findConfigurationProperty($node, SilverstripeConstants::PROPERTY_HAS_ONE);
+
+        // Migrate has_one configuration
+        if ($hasOne instanceof Property) {
+            $node = $this->refactorHasOne($node, $hasOne);
+        }
+
+        $manyMany = $this->propertyFactory->findConfigurationProperty($node, SilverstripeConstants::PROPERTY_MANY_MANY);
+
+        // Migrate many_many to has_many
+        if ($manyMany instanceof Property) {
+            $node = $this->refactorManyMany($node, $manyMany);
+        }
+
+        $hasMany = $this->propertyFactory->findConfigurationProperty($node, SilverstripeConstants::PROPERTY_HAS_MANY);
+
+        // Migrate has_many configuration
+        if ($hasMany instanceof Property) {
+            $node = $this->refactorHasMany($node, $hasMany);
+        }
+
+        if (!$this->hasChanged) {
+            return null;
+        }
+
+        return $node;
+    }
+
+    #[Override]
+    public static function getConfigFile(): string
+    {
+        return SilverstripeSetList::WITH_RECTOR_SERVICES;
+    }
+
+    private function refactorHasOne(Class_ $class, Property $property): Class_
+    {
+        $value = $property->props[0]->default;
+
+        if (!$value instanceof Array_) {
+            return $class;
+        }
+
+        foreach ($value->items as $item) {
+            // Safety checks...
+            if (!$item instanceof ArrayItem) {
+                continue;
+            }
+
+            if ($this->shouldSkipArrayItem($item)) {
+                continue;
+            }
+
+            // Name of the new link class
+            $newValue = new ClassConstFetch(new FullyQualified('SilverStripe\LinkField\Models\Link'), 'class');
+
+            // Check for existing dot notation
+            if ($item->value instanceof Concat) {
+                $newValue = $this->nodeFactory->createConcat([
+                    new ClassConstFetch(new FullyQualified('SilverStripe\LinkField\Models\Link'), 'class'),
+                    $item->value->right,
+                ]);
+            }
+
+            // Safety check
+            if (!$newValue instanceof Expr) {
+                continue;
+            }
+
+            // Rename the link class
+            $item->value = $newValue;
+
+            if (!$item->key instanceof Expr) {
+                continue;
+            }
+
+            $memberName = $this->valueResolver->getValue($item->key);
+
+            if (!is_string($memberName)) {
+                continue;
+            }
+
+            // Add this member to the owns configuration
+            if ($this->shouldAddMemberToOwns($class)) {
+                $this->addMemberToOwns($class, $memberName);
+            }
+        }
+
+        return $class;
+    }
+
+    private function refactorManyMany(Class_ $class, Property $property): Class_
+    {
+        $value = $property->props[0]->default;
+
+        // Safety check
+        if (!$value instanceof Array_) {
+            return $class;
+        }
+
+        foreach ($value->items as $key => $item) {
+            // Safety check
+            if (!$item instanceof ArrayItem) {
+                continue;
+            }
+
+            // Not a gorriecoe link, skip
+            if ($this->shouldSkipArrayItem($item)) {
+                continue;
+            }
+
+            // Add this member to the has_many property
+            $this->addMemberToHasMany($class, $item);
+
+            // Remove this member from the many_many_extraFields property
+            $this->removeMemberFromManyManyExtraFields($class, $item);
+
+            // Remove this member from the property
+            unset($value->items[$key]);
+
+            $this->hasChanged = true;
+        }
+
+        // If many_many is empty, remove it
+        if ($value->items === []) {
+            $this->removeProperty($class, $this->getName($property));
+        }
+
+        return $class;
+    }
+
+    private function addMemberToHasMany(Class_ $class, ArrayItem $arrayItem): void
+    {
+        $hasMany = $this->propertyFactory->findConfigurationProperty($class, SilverstripeConstants::PROPERTY_HAS_MANY);
+
+        if (!$hasMany instanceof Property) {
+            $hasMany = $this->propertyFactory->createArrayConfigurationProperty($class, SilverstripeConstants::PROPERTY_HAS_MANY);
+            $hasMany->props[0]->default = new Array_([]);
+        }
+
+        $value = $hasMany->props[0]->default;
+
+        if (!$value instanceof Array_) {
+            return;
+        }
+
+        $value->items[] = $arrayItem;
+    }
+
+    private function removeMemberFromManyManyExtraFields(Class_ $class, ArrayItem $arrayItem): void
+    {
+        // Skip if there is no key
+        if (!$arrayItem->key instanceof Expr) {
+            return;
+        }
+
+        $manyManyExtraFields = $this->propertyFactory->findConfigurationProperty($class, SilverstripeConstants::PROPERTY_MANY_MANY_EXTRA_FIELDS);
+
+        // Skip if there is no property
+        if (!$manyManyExtraFields instanceof Property) {
+            return;
+        }
+
+        $value = $manyManyExtraFields->props[0]->default;
+
+        // Safety check
+        if (!$value instanceof Array_) {
+            return;
+        }
+
+        foreach ($value->items as $key => $item) {
+            // Safety checks...
+            if (!$item instanceof ArrayItem) {
+                continue;
+            }
+
+            if (!$item->key instanceof Expr) {
+                continue;
+            }
+
+            if ($this->valueResolver->getValue($item->key) !== $this->valueResolver->getValue($arrayItem->key)) {
+                continue;
+            }
+
+            // Remove this member from the property
+            unset($value->items[$key]);
+        }
+
+        // If the property is empty, remove it
+        if ($value->items === []) {
+            $this->removeProperty($class, $this->getName($manyManyExtraFields));
+        }
+    }
+
+    /**
+     * Skip if the array item does not reference `gorriecoe\Link\Models\Link`.
+     */
+    private function shouldSkipArrayItem(ArrayItem $arrayItem): bool
+    {
+        $value = $arrayItem->value;
+
+        if ($value instanceof Concat) {
+            $value = $value->left;
+        }
+
+        if ($value instanceof ClassConstFetch) {
+            return !$this->isName($value->class, 'gorriecoe\Link\Models\Link');
+        }
+
+        return true;
+    }
+
+    private function refactorHasMany(Class_ $class, Property $property): Class_
+    {
+        $value = $property->props[0]->default;
+
+        if (!$value instanceof Array_) {
+            return $class;
+        }
+
+        foreach ($value->items as $item) {
+            // Safety checks...
+            if (!$item instanceof ArrayItem) {
+                continue;
+            }
+
+            if ($this->shouldSkipArrayItem($item)) {
+                continue;
+            }
+
+            // New link class
+            $newValue = $this->nodeFactory->createConcat([
+                new ClassConstFetch(new FullyQualified('SilverStripe\LinkField\Models\Link'), 'class'),
+                new String_('.Owner'),
+            ]);
+
+            // Safety check
+            if (!$newValue instanceof Concat) {
+                continue;
+            }
+
+            $item->value = $newValue;
+
+            $this->hasChanged = true;
+
+            if (!$item->key instanceof Expr) {
+                continue;
+            }
+
+            $memberName = $this->valueResolver->getValue($item->key);
+
+            if (!is_string($memberName)) {
+                continue;
+            }
+
+            // Add this member to the owns configuration
+            if ($this->shouldAddMemberToOwns($class)) {
+                $this->addMemberToOwns($class, $memberName);
+            }
+        }
+
+        return $class;
+    }
+
+    /**
+     * Return false if the class is in `SilverStripe\LinkField\Tasks\GorriecoeMigrationTask::$classes_that_are_not_link_owners`.
+     */
+    private function shouldAddMemberToOwns(Class_ $class): bool
+    {
+        $notOwners = $this->configurationResolver->get('SilverStripe\LinkField\Tasks\GorriecoeMigrationTask', 'classes_that_are_not_link_owners');
+
+        if (!is_array($notOwners) || $notOwners === []) {
+            return true;
+        }
+
+        return !in_array($this->getName($class), $notOwners, true);
+    }
+
+    private function addMemberToOwns(Class_ $class, string $memberName): void
+    {
+        $owns = $this->propertyFactory->findConfigurationProperty($class, SilverstripeConstants::PROPERTY_OWNS);
+
+        if (!$owns instanceof Property) {
+            $owns = $this->propertyFactory->createArrayConfigurationProperty($class, SilverstripeConstants::PROPERTY_OWNS);
+            $owns->props[0]->default = new Array_([]);
+        }
+
+        $value = $owns->props[0]->default;
+
+        // Best not to modify in order to avoid unexpected errors
+        if (!$value instanceof Array_) {
+            return;
+        }
+
+        // Resolve the existing members
+        $resolvedValue = $this->valueResolver->getValue($value);
+
+        // Skip if unresolved
+        if (!is_array($resolvedValue)) {
+            return;
+        }
+
+        // Check that the member isn't already in the array
+        if (in_array($memberName, $resolvedValue, true)) {
+            return;
+        }
+
+        // Add the member to the array
+        $value->items[] = new ArrayItem(new String_($memberName));
+
+        $this->hasChanged = true;
+    }
+
+    private function removeProperty(Class_ $class, string $propertyName): void
+    {
+        foreach ($class->stmts as $key => $stmt) {
+            if (!$stmt instanceof Property) {
+                continue;
+            }
+
+            if (!$this->isName($stmt, $propertyName)) {
+                continue;
+            }
+
+            unset($class->stmts[$key]);
+        }
+    }
+}

--- a/rules/LinkField/Rector/Class_/GorriecoeLinkToSilverstripeLinkRector.php
+++ b/rules/LinkField/Rector/Class_/GorriecoeLinkToSilverstripeLinkRector.php
@@ -30,6 +30,8 @@ use function is_array;
 use function is_string;
 
 /**
+ * @changelog https://github.com/silverstripe/silverstripe-linkfield/blob/4/docs/en/09_migrating/02_gorriecoe-migration.md
+ *
  * @see \Cambis\SilverstripeRector\Tests\LinkField\Rector\Class_\GorriecoeLinkToSilverstripeLinkRector\GorriecoeLinkToSilverstripeLinkRectorTest
  */
 final class GorriecoeLinkToSilverstripeLinkRector extends AbstractRector implements RelatedConfigInterface
@@ -181,6 +183,8 @@ CODE_SAMPLE
 
             // Rename the link class
             $item->value = $newValue;
+
+            $this->hasChanged = true;
 
             if (!$item->key instanceof Expr) {
                 continue;

--- a/rules/LinkField/Rector/StaticCall/GorriecoeLinkFieldToSilverstripeLinkFieldRector.php
+++ b/rules/LinkField/Rector/StaticCall/GorriecoeLinkFieldToSilverstripeLinkFieldRector.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\SilverstripeRector\LinkField\Rector\StaticCall;
+
+use Cambis\Silverstan\ConfigurationResolver\ConfigurationResolver;
+use Cambis\SilverstripeRector\Set\ValueObject\SilverstripeSetList;
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name\FullyQualified;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Type\Type;
+use Rector\Contract\DependencyInjection\RelatedConfigInterface;
+use Rector\PhpParser\Node\Value\ValueResolver;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use function is_array;
+use function is_bool;
+use function is_string;
+
+/**
+ * @see \Cambis\SilverstripeRector\Tests\LinkField\Rector\StaticCall\GorriecoeLinkFieldToSilverstripeLinkFieldRector\GorriecoeLinkFieldToSilverstripeLinkFieldRectorTest
+ */
+final class GorriecoeLinkFieldToSilverstripeLinkFieldRector extends AbstractRector implements RelatedConfigInterface
+{
+    /**
+     * @var array<string, string>
+     */
+    private const LINK_TYPES = [
+        'URL' => 'SilverStripe\LinkField\Models\ExternalLink',
+        'Email' => 'SilverStripe\LinkField\Models\EmailLink',
+        'Phone' => 'SilverStripe\LinkField\Models\PhoneLink',
+        'File' => 'SilverStripe\LinkField\Models\FileLink',
+        'SiteTree' => 'SilverStripe\LinkField\Models\SiteTreeLink',
+    ];
+
+    public function __construct(
+        private readonly ConfigurationResolver $configurationResolver,
+        private readonly ValueResolver $valueResolver
+    ) {
+    }
+
+    #[Override]
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Migrate `gorriecoe\LinkField\LinkField` to `SilverStripe\LinkField\Form\LinkField`.', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+\gorriecoe\LinkField\LinkField::create('Link', 'Link', $this, ['types' => ['SiteTree']]);
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+\SilverStripe\LinkField\Form\LinkField::create('Link', 'Link')
+    ->setAllowedTypes([\SilverStripe\LinkField\Models\SiteTreeLink::class]);
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    #[Override]
+    public function getNodeTypes(): array
+    {
+        return [StaticCall::class];
+    }
+
+    /**
+     * @param StaticCall $node
+     */
+    #[Override]
+    public function refactor(Node $node): ?Node
+    {
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
+        if (!$this->isName($node->class, 'gorriecoe\LinkField\LinkField')) {
+            return null;
+        }
+
+        if (!$this->isName($node->name, 'create')) {
+            return null;
+        }
+
+        $node->class = $this->resolveFormFieldClass($node);
+
+        // Remove parent argument
+        if (isset($node->args[2])) {
+            unset($node->args[2]);
+        }
+
+        if (isset($node->args[3])) {
+            return $this->refactorLinkConfig($node);
+        }
+
+        return $node;
+    }
+
+    #[Override]
+    public static function getConfigFile(): string
+    {
+        return SilverstripeSetList::WITH_RECTOR_SERVICES;
+    }
+
+    /**
+     * Resolve the parent.
+     */
+    private function resolveParentClass(Type $type): ?ClassReflection
+    {
+        foreach ($type->getObjectClassReflections() as $classReflection) {
+            if (!$classReflection->is('SilverStripe\ORM\DataObject')) {
+                continue;
+            }
+
+            return $classReflection;
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolve the class of form field to use. Single relations should use `LinkField`, while multi relations should use `MultiLinkField`.
+     */
+    private function resolveFormFieldClass(StaticCall $staticCall): FullyQualified
+    {
+        $name = $staticCall->getArgs()[0] ?? null;
+
+        if (!$name instanceof Arg) {
+            return new FullyQualified('SilverStripe\LinkField\Form\LinkField');
+        }
+
+        $parent = $staticCall->getArgs()[2] ?? null;
+
+        if (!$parent instanceof Arg) {
+            return new FullyQualified('SilverStripe\LinkField\Form\LinkField');
+        }
+
+        $nameValue = $this->valueResolver->getValue($name);
+        $parentClass = $this->resolveParentClass($this->getType($parent->value));
+
+        // Couldn't resolve name, fallback
+        if (!is_string($nameValue)) {
+            return new FullyQualified('SilverStripe\LinkField\Form\LinkField');
+        }
+
+        // Couldn't resolve parent, fallback
+        if (!$parentClass instanceof ClassReflection) {
+            return new FullyQualified('SilverStripe\LinkField\Form\LinkField');
+        }
+
+        $hasMany = $this->configurationResolver->get($parentClass->getName(), 'has_many');
+
+        // Check if link is a has many
+        if (is_array($hasMany) && isset($hasMany[$nameValue])) {
+            return new FullyQualified('SilverStripe\LinkField\Form\MultiLinkField');
+        }
+
+        $manyMany = $this->configurationResolver->get($parentClass->getName(), 'many_many');
+
+        // Check if link is a many many
+        if (is_array($manyMany) && isset($manyMany[$nameValue])) {
+            return new FullyQualified('SilverStripe\LinkField\Form\MultiLinkField');
+        }
+
+        // Fallback
+        return new FullyQualified('SilverStripe\LinkField\Form\LinkField');
+    }
+
+    private function refactorLinkConfig(StaticCall $node): Node
+    {
+        $linkConfigArg = $node->getArgs()[3] ?? null;
+
+        if (!$linkConfigArg instanceof Arg) {
+            return $node;
+        }
+
+        // Get the value of linkConfig
+        $linkConfig = $this->valueResolver->getValue($linkConfigArg);
+
+        // Remove linkConfig argument
+        unset($node->args[3]);
+
+        if (!is_array($linkConfig)) {
+            return $node;
+        }
+
+        // Migrate types to LinkField::setAllowedTypes()
+        if (isset($linkConfig['types']) && is_array($linkConfig['types'])) {
+            $allowedTypes = [];
+
+            foreach ($linkConfig['types'] as $allowedType) {
+                if (!isset(self::LINK_TYPES[$allowedType])) {
+                    continue;
+                }
+
+                $allowedTypes[] = new ClassConstFetch(new FullyQualified(self::LINK_TYPES[$allowedType]), 'class');
+            }
+
+            $node = $this->nodeFactory->createMethodCall(
+                $node,
+                'setAllowedTypes',
+                [$this->nodeFactory->createArray($allowedTypes)]
+            );
+        }
+
+        // Migrate title_display to LinkField::setExcludeLinkTextField()
+        if (isset($linkConfig['title_display'])) {
+            $titleDisplay = $linkConfig['title_display'];
+
+            if (is_bool($titleDisplay)) {
+                $node = $this->nodeFactory->createMethodCall(
+                    $node,
+                    'setExcludeLinkTextField',
+                    [$titleDisplay]
+                );
+            }
+        }
+
+        return $node;
+    }
+}

--- a/rules/LinkField/Rector/StaticCall/GorriecoeLinkFieldToSilverstripeLinkFieldRector.php
+++ b/rules/LinkField/Rector/StaticCall/GorriecoeLinkFieldToSilverstripeLinkFieldRector.php
@@ -24,6 +24,8 @@ use function is_bool;
 use function is_string;
 
 /**
+ * @changelog https://github.com/silverstripe/silverstripe-linkfield/blob/4/docs/en/09_migrating/02_gorriecoe-migration.md
+ *
  * @see \Cambis\SilverstripeRector\Tests\LinkField\Rector\StaticCall\GorriecoeLinkFieldToSilverstripeLinkFieldRector\GorriecoeLinkFieldToSilverstripeLinkFieldRectorTest
  */
 final class GorriecoeLinkFieldToSilverstripeLinkFieldRector extends AbstractRector implements RelatedConfigInterface

--- a/src/NodeAnalyser/ClassAnalyser.php
+++ b/src/NodeAnalyser/ClassAnalyser.php
@@ -16,6 +16,27 @@ final readonly class ClassAnalyser
     ) {
     }
 
+    public function isDataObject(Class_ $class): bool
+    {
+        $className = $this->nodeNameResolver->getName($class);
+
+        if ($className === null) {
+            return false;
+        }
+
+        if (!$this->reflectionProvider->hasClass($className)) {
+            return false;
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($className);
+
+        if ($classReflection->isSubclassOf('SilverStripe\Core\Extension')) {
+            return true;
+        }
+
+        return $classReflection->is('SilverStripe\ORM\DataObject');
+    }
+
     public function isExtension(Class_ $class): bool
     {
         $className = (string) $this->nodeNameResolver->getName($class);

--- a/src/NodeFactory/PropertyFactory.php
+++ b/src/NodeFactory/PropertyFactory.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\SilverstripeRector\NodeFactory;
+
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Property;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\StringType;
+use Rector\NodeManipulator\ClassInsertManipulator;
+use Rector\PhpParser\Node\NodeFactory;
+
+final readonly class PropertyFactory
+{
+    public function __construct(
+        private ClassInsertManipulator $classInsertManipulator,
+        private NodeFactory $nodeFactory
+    ) {
+    }
+
+    public function findConfigurationProperty(Class_ $class, string $propertyName): ?Property
+    {
+        $property = $class->getProperty($propertyName);
+
+        if (!$property instanceof Property) {
+            return null;
+        }
+
+        if (!$property->isPrivate()) {
+            return null;
+        }
+
+        if (!$property->isStatic()) {
+            return null;
+        }
+
+        return $property;
+    }
+
+    public function createArrayConfigurationProperty(Class_ $class, string $propertyName): Property
+    {
+        $property = $this->findConfigurationProperty($class, $propertyName);
+
+        if ($property instanceof Property) {
+            return $property;
+        }
+
+        $property = $this->nodeFactory->createPrivatePropertyFromNameAndType(
+            $propertyName,
+            new ArrayType(new IntegerType(), new StringType())
+        );
+
+        $property->flags = Class_::MODIFIER_PRIVATE | Class_::MODIFIER_STATIC;
+
+        $this->classInsertManipulator->addAsFirstMethod($class, $property);
+
+        return $property;
+    }
+}

--- a/src/Set/ValueObject/SilverstripeSetList.php
+++ b/src/Set/ValueObject/SilverstripeSetList.php
@@ -26,4 +26,6 @@ final class SilverstripeSetList
      * Provides all the custom services that are required in order to run all the rules.
      */
     public const WITH_RECTOR_SERVICES = __DIR__ . '/../../../config/rector-services.php';
+
+    public const GORRIECOE_LINK_TO_SILVERSTRIPE_LINKFIELD = __DIR__ . '/../../../config/set/gorriecoe-link-to-silverstripe-linkfield.php';
 }

--- a/src/ValueObject/SilverstripeConstants.php
+++ b/src/ValueObject/SilverstripeConstants.php
@@ -22,6 +22,10 @@ final class SilverstripeConstants
 
     public const PROPERTY_MANY_MANY = 'many_many';
 
+    public const PROPERTY_MANY_MANY_EXTRA_FIELDS = 'many_many_extraFields';
+
+    public const PROPERTY_OWNS = 'owns';
+
     public const METHOD_ADD_FIELD_TO_TAB = 'addFieldToTab';
 
     public const METHOD_ADD_FIELDS_TO_TAB = 'addFieldsToTab';

--- a/tests/rules/LinkField/Rector/Class_/GorriecoeLinkToSilverstripeLinkRector/Fixture/already_owns_link.php.inc
+++ b/tests/rules/LinkField/Rector/Class_/GorriecoeLinkToSilverstripeLinkRector/Fixture/already_owns_link.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\LinkField\Rector\Class_\GorriecoeLinkToSilverstripeLinkRector\Fixture;
+
+class AlreadyOwnsLink extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+{
+    private static array $has_one = [
+        'HasOneLink' => \gorriecoe\Link\Models\Link::class,
+    ];
+
+    private static array $owns = [
+        'HasOneLink',
+    ];
+}
+
+?>
+-----
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\LinkField\Rector\Class_\GorriecoeLinkToSilverstripeLinkRector\Fixture;
+
+class AlreadyOwnsLink extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+{
+    private static array $has_one = [
+        'HasOneLink' => \SilverStripe\LinkField\Models\Link::class,
+    ];
+
+    private static array $owns = [
+        'HasOneLink',
+    ];
+}
+
+?>

--- a/tests/rules/LinkField/Rector/Class_/GorriecoeLinkToSilverstripeLinkRector/Fixture/does_not_own_links.php.inc
+++ b/tests/rules/LinkField/Rector/Class_/GorriecoeLinkToSilverstripeLinkRector/Fixture/does_not_own_links.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\LinkField\Rector\Class_\GorriecoeLinkToSilverstripeLinkRector\Fixture;
+
+class DoesNotOwnLinks extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+{
+    private static array $has_one = [
+        'HasOneLink' => \gorriecoe\Link\Models\Link::class,
+    ];
+
+    private static array $has_many = [
+        'HasManyLinks' => \gorriecoe\Link\Models\Link::class . '.Owner',
+    ];
+
+    private static array $many_many = [
+        'ManyManyLinks' => \gorriecoe\Link\Models\Link::class . '.Owner',
+    ];
+}
+
+?>
+-----
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\LinkField\Rector\Class_\GorriecoeLinkToSilverstripeLinkRector\Fixture;
+
+class DoesNotOwnLinks extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+{
+    private static array $has_one = [
+        'HasOneLink' => \SilverStripe\LinkField\Models\Link::class,
+    ];
+
+    private static array $has_many = [
+        'HasManyLinks' => \SilverStripe\LinkField\Models\Link::class . '.Owner', 'ManyManyLinks' => \SilverStripe\LinkField\Models\Link::class . '.Owner',
+    ];
+}
+
+?>

--- a/tests/rules/LinkField/Rector/Class_/GorriecoeLinkToSilverstripeLinkRector/Fixture/has_many_links.php.inc
+++ b/tests/rules/LinkField/Rector/Class_/GorriecoeLinkToSilverstripeLinkRector/Fixture/has_many_links.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\LinkField\Rector\Class_\GorriecoeLinkToSilverstripeLinkRector\Fixture;
+
+class HasManyLinks extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+{
+    private static array $has_many = [
+        'HasManyLinks' => \gorriecoe\Link\Models\Link::class,
+    ];
+}
+
+?>
+-----
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\LinkField\Rector\Class_\GorriecoeLinkToSilverstripeLinkRector\Fixture;
+
+class HasManyLinks extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+{
+    private static array $has_many = [
+        'HasManyLinks' => \SilverStripe\LinkField\Models\Link::class . '.Owner',
+    ];
+    private static array $owns = ['HasManyLinks'];
+}
+
+?>

--- a/tests/rules/LinkField/Rector/Class_/GorriecoeLinkToSilverstripeLinkRector/Fixture/has_one_link.php.inc
+++ b/tests/rules/LinkField/Rector/Class_/GorriecoeLinkToSilverstripeLinkRector/Fixture/has_one_link.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\LinkField\Rector\Class_\GorriecoeLinkToSilverstripeLinkRector\Fixture;
+
+class HasOneLink extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+{
+    private static array $has_one = [
+        'HasOneLink' => \gorriecoe\Link\Models\Link::class,
+    ];
+}
+
+?>
+-----
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\LinkField\Rector\Class_\GorriecoeLinkToSilverstripeLinkRector\Fixture;
+
+class HasOneLink extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+{
+    private static array $has_one = [
+        'HasOneLink' => \SilverStripe\LinkField\Models\Link::class,
+    ];
+    private static array $owns = ['HasOneLink'];
+}
+
+?>

--- a/tests/rules/LinkField/Rector/Class_/GorriecoeLinkToSilverstripeLinkRector/Fixture/many_many_links.php.inc
+++ b/tests/rules/LinkField/Rector/Class_/GorriecoeLinkToSilverstripeLinkRector/Fixture/many_many_links.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\LinkField\Rector\Class_\GorriecoeLinkToSilverstripeLinkRector\Fixture;
+
+class ManyManyLinks extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+{
+    private static array $many_many = [
+        'ManyManyLinks' => \gorriecoe\Link\Models\Link::class,
+    ];
+
+    private static array $many_many_extraFields = [
+        'ManyManyLinks' => [
+            'Sort' => 'Int',
+        ],
+    ];
+}
+
+?>
+-----
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\LinkField\Rector\Class_\GorriecoeLinkToSilverstripeLinkRector\Fixture;
+
+class ManyManyLinks extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+{
+    private static array $has_many = ['ManyManyLinks' => \SilverStripe\LinkField\Models\Link::class . '.Owner'];
+
+    private static array $owns = ['ManyManyLinks'];
+}
+
+?>

--- a/tests/rules/LinkField/Rector/Class_/GorriecoeLinkToSilverstripeLinkRector/GorriecoeLinkToSilverstripeLinkRectorTest.php
+++ b/tests/rules/LinkField/Rector/Class_/GorriecoeLinkToSilverstripeLinkRector/GorriecoeLinkToSilverstripeLinkRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\SilverstripeRector\Tests\LinkField\Rector\Class_\GorriecoeLinkToSilverstripeLinkRector;
+
+use Cambis\SilverstripeRector\Testing\PHPUnit\AbstractSilverstripeRectorTestCase;
+use Iterator;
+use Override;
+
+final class GorriecoeLinkToSilverstripeLinkRectorTest extends AbstractSilverstripeRectorTestCase
+{
+    /**
+     * @dataProvider provideData
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    #[Override]
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/rules/LinkField/Rector/Class_/GorriecoeLinkToSilverstripeLinkRector/_config/config.yml
+++ b/tests/rules/LinkField/Rector/Class_/GorriecoeLinkToSilverstripeLinkRector/_config/config.yml
@@ -1,0 +1,3 @@
+SilverStripe\LinkField\Tasks\GorriecoeMigrationTask:
+  classes_that_are_not_link_owners:
+    - Cambis\SilverstripeRector\Tests\LinkField\Rector\Class_\GorriecoeLinkToSilverstripeLinkRector\Fixture\DoesNotOwnLinks

--- a/tests/rules/LinkField/Rector/Class_/GorriecoeLinkToSilverstripeLinkRector/config/configured_rule.php
+++ b/tests/rules/LinkField/Rector/Class_/GorriecoeLinkToSilverstripeLinkRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Cambis\SilverstripeRector\LinkField\Rector\Class_\GorriecoeLinkToSilverstripeLinkRector;
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withRules([
+        GorriecoeLinkToSilverstripeLinkRector::class,
+    ]);

--- a/tests/rules/LinkField/Rector/StaticCall/GorriecoeLinkFieldToSilverstripeLinkFieldRector/Fixture/has_many_links.php.inc
+++ b/tests/rules/LinkField/Rector/StaticCall/GorriecoeLinkFieldToSilverstripeLinkFieldRector/Fixture/has_many_links.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\LinkField\Rector\StaticCall\GorriecoeLinkFieldToSilverstripeLinkFieldRector\Fixture;
+
+class HasManyLinks extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+{
+    private static array $has_many = [
+        'CtaLinks' => \gorriecoe\Link\Models\Link::class,
+    ];
+
+    public function getCMSFields(): \SilverStripe\Forms\FieldList
+    {
+        return parent::getCMSFields()
+            ->removeByName(['CtaLinks'])
+            ->addFieldToTab(
+                'Root.Main',
+                \gorriecoe\LinkField\LinkField::create('CtaLinks', 'Links', $this, ['types' => ['SiteTree'], 'title_display' => true])
+            );
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\LinkField\Rector\StaticCall\GorriecoeLinkFieldToSilverstripeLinkFieldRector\Fixture;
+
+class HasManyLinks extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+{
+    private static array $has_many = [
+        'CtaLinks' => \gorriecoe\Link\Models\Link::class,
+    ];
+
+    public function getCMSFields(): \SilverStripe\Forms\FieldList
+    {
+        return parent::getCMSFields()
+            ->removeByName(['CtaLinks'])
+            ->addFieldToTab(
+                'Root.Main',
+                \SilverStripe\LinkField\Form\MultiLinkField::create('CtaLinks', 'Links')->setAllowedTypes([\SilverStripe\LinkField\Models\SiteTreeLink::class])->setExcludeLinkTextField(true)
+            );
+    }
+}
+
+?>

--- a/tests/rules/LinkField/Rector/StaticCall/GorriecoeLinkFieldToSilverstripeLinkFieldRector/Fixture/has_many_links_static.php.inc
+++ b/tests/rules/LinkField/Rector/StaticCall/GorriecoeLinkFieldToSilverstripeLinkFieldRector/Fixture/has_many_links_static.php.inc
@@ -2,7 +2,7 @@
 
 namespace Cambis\SilverstripeRector\Tests\LinkField\Rector\StaticCall\GorriecoeLinkFieldToSilverstripeLinkFieldRector\Fixture;
 
-class HasManyLinks extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+class HasManyLinksStatic extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
 {
     private static array $has_many = [
         'CtaLinks' => \gorriecoe\Link\Models\Link::class,
@@ -14,7 +14,7 @@ class HasManyLinks extends \SilverStripe\ORM\DataObject implements \SilverStripe
             ->removeByName(['CtaLinks'])
             ->addFieldToTab(
                 'Root.Main',
-                new \gorriecoe\LinkField\LinkField('CtaLinks', 'Links', $this, ['types' => ['SiteTree'], 'title_display' => true])
+                \gorriecoe\LinkField\LinkField::create('CtaLinks', 'Links', $this, ['types' => ['SiteTree'], 'title_display' => true])
             );
     }
 }
@@ -25,7 +25,7 @@ class HasManyLinks extends \SilverStripe\ORM\DataObject implements \SilverStripe
 
 namespace Cambis\SilverstripeRector\Tests\LinkField\Rector\StaticCall\GorriecoeLinkFieldToSilverstripeLinkFieldRector\Fixture;
 
-class HasManyLinks extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+class HasManyLinksStatic extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
 {
     private static array $has_many = [
         'CtaLinks' => \gorriecoe\Link\Models\Link::class,
@@ -37,7 +37,7 @@ class HasManyLinks extends \SilverStripe\ORM\DataObject implements \SilverStripe
             ->removeByName(['CtaLinks'])
             ->addFieldToTab(
                 'Root.Main',
-                (new \SilverStripe\LinkField\Form\MultiLinkField('CtaLinks', 'Links'))->setAllowedTypes([\SilverStripe\LinkField\Models\SiteTreeLink::class])->setExcludeLinkTextField(true)
+                \SilverStripe\LinkField\Form\MultiLinkField::create('CtaLinks', 'Links')->setAllowedTypes([\SilverStripe\LinkField\Models\SiteTreeLink::class])->setExcludeLinkTextField(true)
             );
     }
 }

--- a/tests/rules/LinkField/Rector/StaticCall/GorriecoeLinkFieldToSilverstripeLinkFieldRector/Fixture/has_one_link.php.inc
+++ b/tests/rules/LinkField/Rector/StaticCall/GorriecoeLinkFieldToSilverstripeLinkFieldRector/Fixture/has_one_link.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\LinkField\Rector\StaticCall\GorriecoeLinkFieldToSilverstripeLinkFieldRector\Fixture;
+
+class HasOneLink extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+{
+    private static array $has_one = [
+        'CtaLink' => \gorriecoe\Link\Models\Link::class,
+    ];
+
+    public function getCMSFields(): \SilverStripe\Forms\FieldList
+    {
+        return parent::getCMSFields()
+            ->removeByName(['CtaLinkID'])
+            ->addFieldToTab(
+                'Root.Main',
+                \gorriecoe\LinkField\LinkField::create('CtaLinks', 'Links', $this, ['types' => ['SiteTree'], 'title_display' => true])
+            );
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\LinkField\Rector\StaticCall\GorriecoeLinkFieldToSilverstripeLinkFieldRector\Fixture;
+
+class HasOneLink extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+{
+    private static array $has_one = [
+        'CtaLink' => \gorriecoe\Link\Models\Link::class,
+    ];
+
+    public function getCMSFields(): \SilverStripe\Forms\FieldList
+    {
+        return parent::getCMSFields()
+            ->removeByName(['CtaLinkID'])
+            ->addFieldToTab(
+                'Root.Main',
+                \SilverStripe\LinkField\Form\LinkField::create('CtaLinks', 'Links')->setAllowedTypes([\SilverStripe\LinkField\Models\SiteTreeLink::class])->setExcludeLinkTextField(true)
+            );
+    }
+}
+
+?>

--- a/tests/rules/LinkField/Rector/StaticCall/GorriecoeLinkFieldToSilverstripeLinkFieldRector/Fixture/has_one_link_static.php.inc
+++ b/tests/rules/LinkField/Rector/StaticCall/GorriecoeLinkFieldToSilverstripeLinkFieldRector/Fixture/has_one_link_static.php.inc
@@ -2,7 +2,7 @@
 
 namespace Cambis\SilverstripeRector\Tests\LinkField\Rector\StaticCall\GorriecoeLinkFieldToSilverstripeLinkFieldRector\Fixture;
 
-class HasOneLink extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+class HasOneLinkStatic extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
 {
     private static array $has_one = [
         'CtaLink' => \gorriecoe\Link\Models\Link::class,
@@ -14,7 +14,7 @@ class HasOneLink extends \SilverStripe\ORM\DataObject implements \SilverStripe\D
             ->removeByName(['CtaLinkID'])
             ->addFieldToTab(
                 'Root.Main',
-                new \gorriecoe\LinkField\LinkField('CtaLinks', 'Links', $this, ['types' => ['SiteTree'], 'title_display' => true])
+                \gorriecoe\LinkField\LinkField::create('CtaLinks', 'Links', $this, ['types' => ['SiteTree'], 'title_display' => true])
             );
     }
 }
@@ -25,7 +25,7 @@ class HasOneLink extends \SilverStripe\ORM\DataObject implements \SilverStripe\D
 
 namespace Cambis\SilverstripeRector\Tests\LinkField\Rector\StaticCall\GorriecoeLinkFieldToSilverstripeLinkFieldRector\Fixture;
 
-class HasOneLink extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+class HasOneLinkStatic extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
 {
     private static array $has_one = [
         'CtaLink' => \gorriecoe\Link\Models\Link::class,
@@ -37,7 +37,7 @@ class HasOneLink extends \SilverStripe\ORM\DataObject implements \SilverStripe\D
             ->removeByName(['CtaLinkID'])
             ->addFieldToTab(
                 'Root.Main',
-                (new \SilverStripe\LinkField\Form\LinkField('CtaLinks', 'Links'))->setAllowedTypes([\SilverStripe\LinkField\Models\SiteTreeLink::class])->setExcludeLinkTextField(true)
+                \SilverStripe\LinkField\Form\LinkField::create('CtaLinks', 'Links')->setAllowedTypes([\SilverStripe\LinkField\Models\SiteTreeLink::class])->setExcludeLinkTextField(true)
             );
     }
 }

--- a/tests/rules/LinkField/Rector/StaticCall/GorriecoeLinkFieldToSilverstripeLinkFieldRector/Fixture/many_many_links.php.inc
+++ b/tests/rules/LinkField/Rector/StaticCall/GorriecoeLinkFieldToSilverstripeLinkFieldRector/Fixture/many_many_links.php.inc
@@ -14,7 +14,7 @@ class ManyManyLinks extends \SilverStripe\ORM\DataObject implements \SilverStrip
             ->removeByName(['CtaLinks'])
             ->addFieldToTab(
                 'Root.Main',
-                \gorriecoe\LinkField\LinkField::create('CtaLinks', 'Links', $this, ['types' => ['SiteTree'], 'title_display' => true])
+                new \gorriecoe\LinkField\LinkField('CtaLinks', 'Links', $this, ['types' => ['SiteTree'], 'title_display' => true])
             );
     }
 }
@@ -37,7 +37,7 @@ class ManyManyLinks extends \SilverStripe\ORM\DataObject implements \SilverStrip
             ->removeByName(['CtaLinks'])
             ->addFieldToTab(
                 'Root.Main',
-                \SilverStripe\LinkField\Form\MultiLinkField::create('CtaLinks', 'Links')->setAllowedTypes([\SilverStripe\LinkField\Models\SiteTreeLink::class])->setExcludeLinkTextField(true)
+                (new \SilverStripe\LinkField\Form\MultiLinkField('CtaLinks', 'Links'))->setAllowedTypes([\SilverStripe\LinkField\Models\SiteTreeLink::class])->setExcludeLinkTextField(true)
             );
     }
 }

--- a/tests/rules/LinkField/Rector/StaticCall/GorriecoeLinkFieldToSilverstripeLinkFieldRector/Fixture/many_many_links.php.inc
+++ b/tests/rules/LinkField/Rector/StaticCall/GorriecoeLinkFieldToSilverstripeLinkFieldRector/Fixture/many_many_links.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\LinkField\Rector\StaticCall\GorriecoeLinkFieldToSilverstripeLinkFieldRector\Fixture;
+
+class ManyManyLinks extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+{
+    private static array $many_many = [
+        'CtaLinks' => \gorriecoe\Link\Models\Link::class,
+    ];
+
+    public function getCMSFields(): \SilverStripe\Forms\FieldList
+    {
+        return parent::getCMSFields()
+            ->removeByName(['CtaLinks'])
+            ->addFieldToTab(
+                'Root.Main',
+                \gorriecoe\LinkField\LinkField::create('CtaLinks', 'Links', $this, ['types' => ['SiteTree'], 'title_display' => true])
+            );
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\LinkField\Rector\StaticCall\GorriecoeLinkFieldToSilverstripeLinkFieldRector\Fixture;
+
+class ManyManyLinks extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+{
+    private static array $many_many = [
+        'CtaLinks' => \gorriecoe\Link\Models\Link::class,
+    ];
+
+    public function getCMSFields(): \SilverStripe\Forms\FieldList
+    {
+        return parent::getCMSFields()
+            ->removeByName(['CtaLinks'])
+            ->addFieldToTab(
+                'Root.Main',
+                \SilverStripe\LinkField\Form\MultiLinkField::create('CtaLinks', 'Links')->setAllowedTypes([\SilverStripe\LinkField\Models\SiteTreeLink::class])->setExcludeLinkTextField(true)
+            );
+    }
+}
+
+?>

--- a/tests/rules/LinkField/Rector/StaticCall/GorriecoeLinkFieldToSilverstripeLinkFieldRector/Fixture/many_many_links_static.php.inc
+++ b/tests/rules/LinkField/Rector/StaticCall/GorriecoeLinkFieldToSilverstripeLinkFieldRector/Fixture/many_many_links_static.php.inc
@@ -2,9 +2,9 @@
 
 namespace Cambis\SilverstripeRector\Tests\LinkField\Rector\StaticCall\GorriecoeLinkFieldToSilverstripeLinkFieldRector\Fixture;
 
-class HasManyLinks extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+class ManyManyLinksStatic extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
 {
-    private static array $has_many = [
+    private static array $many_many = [
         'CtaLinks' => \gorriecoe\Link\Models\Link::class,
     ];
 
@@ -14,7 +14,7 @@ class HasManyLinks extends \SilverStripe\ORM\DataObject implements \SilverStripe
             ->removeByName(['CtaLinks'])
             ->addFieldToTab(
                 'Root.Main',
-                new \gorriecoe\LinkField\LinkField('CtaLinks', 'Links', $this, ['types' => ['SiteTree'], 'title_display' => true])
+                \gorriecoe\LinkField\LinkField::create('CtaLinks', 'Links', $this, ['types' => ['SiteTree'], 'title_display' => true])
             );
     }
 }
@@ -25,9 +25,9 @@ class HasManyLinks extends \SilverStripe\ORM\DataObject implements \SilverStripe
 
 namespace Cambis\SilverstripeRector\Tests\LinkField\Rector\StaticCall\GorriecoeLinkFieldToSilverstripeLinkFieldRector\Fixture;
 
-class HasManyLinks extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+class ManyManyLinksStatic extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
 {
-    private static array $has_many = [
+    private static array $many_many = [
         'CtaLinks' => \gorriecoe\Link\Models\Link::class,
     ];
 
@@ -37,7 +37,7 @@ class HasManyLinks extends \SilverStripe\ORM\DataObject implements \SilverStripe
             ->removeByName(['CtaLinks'])
             ->addFieldToTab(
                 'Root.Main',
-                (new \SilverStripe\LinkField\Form\MultiLinkField('CtaLinks', 'Links'))->setAllowedTypes([\SilverStripe\LinkField\Models\SiteTreeLink::class])->setExcludeLinkTextField(true)
+                \SilverStripe\LinkField\Form\MultiLinkField::create('CtaLinks', 'Links')->setAllowedTypes([\SilverStripe\LinkField\Models\SiteTreeLink::class])->setExcludeLinkTextField(true)
             );
     }
 }

--- a/tests/rules/LinkField/Rector/StaticCall/GorriecoeLinkFieldToSilverstripeLinkFieldRector/GorriecoeLinkFieldToSilverstripeLinkFieldRectorTest.php
+++ b/tests/rules/LinkField/Rector/StaticCall/GorriecoeLinkFieldToSilverstripeLinkFieldRector/GorriecoeLinkFieldToSilverstripeLinkFieldRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\SilverstripeRector\Tests\LinkField\Rector\StaticCall\GorriecoeLinkFieldToSilverstripeLinkFieldRector;
+
+use Cambis\SilverstripeRector\Testing\PHPUnit\AbstractSilverstripeRectorTestCase;
+use Iterator;
+use Override;
+
+final class GorriecoeLinkFieldToSilverstripeLinkFieldRectorTest extends AbstractSilverstripeRectorTestCase
+{
+    /**
+     * @dataProvider provideData
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    #[Override]
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/rules/LinkField/Rector/StaticCall/GorriecoeLinkFieldToSilverstripeLinkFieldRector/config/configured_rule.php
+++ b/tests/rules/LinkField/Rector/StaticCall/GorriecoeLinkFieldToSilverstripeLinkFieldRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Cambis\SilverstripeRector\LinkField\Rector\StaticCall\GorriecoeLinkFieldToSilverstripeLinkFieldRector;
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withRules([
+        GorriecoeLinkFieldToSilverstripeLinkFieldRector::class,
+    ]);


### PR DESCRIPTION
## Description ✍️

- Add rectors to migrate gorriecoe link to silverstripe linkfield
- Add new set `SilverstripeSetList::GORRIECOE_LINK_TO_SILVERSTRIPE_LINKFIELD`
- Based on docs from https://github.com/silverstripe/silverstripe-linkfield/blob/4/docs/en/09_migrating/02_gorriecoe-migration.md

## DoD checklist ✅

- [x] I have performed a self-review of my code
- [x] My code adheres to the [coding standards](https://github.com/Cambis/silverstripe-rector/blob/main/CONTRIBUTING.md#coding-standards-️)
- [x] My commit messages adhere to the [commit standards](https://github.com/Cambis/silverstripe-rector/blob/main/CONTRIBUTING.md#commit-standards-️).
- [x] My code has been [tested](https://github.com/Cambis/silverstripe-rector/blob/main/CONTRIBUTING.md#testing-).
- [x] I have added a [changeset](https://github.com/Cambis/silverstripe-rector/blob/main/CONTRIBUTING.md#making-a-pull-request-).
