### PR TITLE
Fix default classname typo ControllerHasCurrToInstanceofRector

### DIFF
--- a/.changeset/dull-rivers-jump.md
+++ b/.changeset/dull-rivers-jump.md
@@ -1,0 +1,5 @@
+---
+"@cambis/silverstripe-rector": patch
+---
+
+Address typo in default classname ControllerHasCurrToInstanceofRector

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -680,7 +680,7 @@ Migrate `ViewableData::cachedCall()` to `ViewableData::obj()`.
 
 Migrate `Controller::has_curr()` check to `Controller::curr() instanceof Controller`.
 
-- class: [`Cambis\SilverstripeRector\Silverstripe60\Rector\StaticCall\ControllerHasCurrToInstanceofRector`](../rules/Silverstripe60/Rector/StaticCall/ControllerHasCurrToInstanceOfRector.php)
+- class: [`Cambis\SilverstripeRector\Silverstripe60\Rector\StaticCall\ControllerHasCurrToInstanceofRector`](../rules/Silverstripe60/Rector/StaticCall/ControllerHasCurrToInstanceofRector.php)
 
 ```diff
 -if (\SilverStripe\Control\Controller::has_curr()) {

--- a/rules/Silverstripe60/Rector/StaticCall/ControllerHasCurrToInstanceofRector.php
+++ b/rules/Silverstripe60/Rector/StaticCall/ControllerHasCurrToInstanceofRector.php
@@ -62,7 +62,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $staticCall = $this->nodeFactory->createStaticCall($this->getName($node->class) ?? 'SilverStri[e\Control\Controller', 'curr');
+        $staticCall = $this->nodeFactory->createStaticCall($this->getName($node->class) ?? 'SilverStripe\Control\Controller', 'curr');
 
         return $this->createExprInstanceof($staticCall, new ObjectType('SilverStripe\Control\Controller'));
     }


### PR DESCRIPTION
## Description ✍️

- As per title

## DoD checklist ✅

- [x] I have performed a self-review of my code
- [x] My code adheres to the [coding standards](https://github.com/Cambis/silverstripe-rector/blob/main/CONTRIBUTING.md#coding-standards-️)
- [x] My commit messages adhere to the [commit standards](https://github.com/Cambis/silverstripe-rector/blob/main/CONTRIBUTING.md#commit-standards-️).
- [x] My code has been [tested](https://github.com/Cambis/silverstripe-rector/blob/main/CONTRIBUTING.md#testing-).
- [x] I have added a [changeset](https://github.com/Cambis/silverstripe-rector/blob/main/CONTRIBUTING.md#making-a-pull-request-).
