### PR TITLE
Add RenameConfigurationPropertyRector

### DIFF
--- a/.changeset/blue-wasps-study.md
+++ b/.changeset/blue-wasps-study.md
@@ -1,0 +1,5 @@
+---
+"@cambis/silverstripe-rector": minor
+---
+
+Add RenameConfigurationPropertyRector

--- a/build/composer-php-74.json
+++ b/build/composer-php-74.json
@@ -9,7 +9,7 @@
   ],
   "require": {
       "php": "^7.4 || ^8.0",
-      "cambis/silverstan": "^2.0",
+      "cambis/silverstan": "^2.0.1",
       "rector/rector": "^2.0"
   },
   "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "symplify/easy-coding-standard": "^12.0",
         "symplify/phpstan-extensions": "^12.0",
         "symplify/phpstan-rules": "^14.0",
+        "symplify/rule-doc-generator": "^12.2",
         "symplify/vendor-patches": "^11.3"
     },
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "php": "^8.3",
-        "cambis/silverstan": "^2.0",
+        "cambis/silverstan": "^2.0.1",
         "rector/rector": "^2.0"
     },
     "require-dev": {

--- a/config/set/silverstripe54.php
+++ b/config/set/silverstripe54.php
@@ -3,17 +3,17 @@
 declare(strict_types=1);
 
 use Cambis\SilverstripeRector\Configuration\SilverstripeOption;
+use Cambis\SilverstripeRector\Renaming\Rector\Class_\RenameConfigurationPropertyRector;
 use Cambis\SilverstripeRector\Silverstripe54\Rector\MethodCall\FormFieldExtendValidationResultToExtendRector;
 use Cambis\SilverstripeRector\Silverstripe54\Rector\MethodCall\RemoteFileModalExtensionGetMethodsRector;
 use Cambis\SilverstripeRector\Silverstripe54\Rector\MethodCall\ViewableDataCachedCallToObjRector;
 use Cambis\SilverstripeRector\Silverstripe54\Rector\StaticCall\SSViewerGetBaseTagRector;
+use Cambis\SilverstripeRector\Tests\Renaming\Rector\Class_\RenameConfigurationPropertyRector\Fixture\RenameConfigurationProperty;
 use Rector\Arguments\Rector\ClassMethod\ReplaceArgumentDefaultValueRector;
 use Rector\Arguments\ValueObject\ReplaceArgumentDefaultValue;
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
-use Rector\Renaming\Rector\PropertyFetch\RenamePropertyRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
-use Rector\Renaming\ValueObject\RenameProperty;
 use Rector\Transform\Rector\Assign\PropertyFetchToMethodCallRector;
 use Rector\Transform\Rector\MethodCall\MethodCallToStaticCallRector;
 use Rector\Transform\ValueObject\MethodCallToStaticCall;
@@ -85,8 +85,8 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(SSViewerGetBaseTagRector::class);
 
     // https://github.com/silverstripe/silverstripe-framework/commit/5b16f7de82037e9363f5ff6402d40652dae42614
-    $rectorConfig->ruleWithConfiguration(RenamePropertyRector::class, [
-        new RenameProperty('SilverStripe\ORM\DataObject', 'description', 'class_description'),
+    $rectorConfig->ruleWithConfiguration(RenameConfigurationPropertyRector::class, [
+        new RenameConfigurationProperty('SilverStripe\ORM\DataObject', 'description', 'class_description'),
     ]);
 
     // https://github.com/silverstripe/silverstripe-framework/commit/15683cfd9839a2af012999e28a577592c6cdcab9

--- a/config/set/silverstripe54.php
+++ b/config/set/silverstripe54.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 use Cambis\SilverstripeRector\Configuration\SilverstripeOption;
 use Cambis\SilverstripeRector\Renaming\Rector\Class_\RenameConfigurationPropertyRector;
+use Cambis\SilverstripeRector\Renaming\ValueObject\RenameConfigurationProperty;
 use Cambis\SilverstripeRector\Silverstripe54\Rector\MethodCall\FormFieldExtendValidationResultToExtendRector;
 use Cambis\SilverstripeRector\Silverstripe54\Rector\MethodCall\RemoteFileModalExtensionGetMethodsRector;
 use Cambis\SilverstripeRector\Silverstripe54\Rector\MethodCall\ViewableDataCachedCallToObjRector;
 use Cambis\SilverstripeRector\Silverstripe54\Rector\StaticCall\SSViewerGetBaseTagRector;
-use Cambis\SilverstripeRector\Tests\Renaming\Rector\Class_\RenameConfigurationPropertyRector\Fixture\RenameConfigurationProperty;
 use Rector\Arguments\Rector\ClassMethod\ReplaceArgumentDefaultValueRector;
 use Rector\Arguments\ValueObject\ReplaceArgumentDefaultValue;
 use Rector\Config\RectorConfig;

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 32 Rules Overview
+# 33 Rules Overview
 
 <br>
 
@@ -8,7 +8,7 @@
 
 - [LinkField](#linkfield) (5)
 
-- [Renaming](#renaming) (1)
+- [Renaming](#renaming) (2)
 
 - [Silverstripe413](#silverstripe413) (9)
 
@@ -209,6 +209,29 @@ Migrate legacy `SilverStripe\LinkField\Model\Link` configuration to `SilverStrip
 <br>
 
 ## Renaming
+
+### RenameConfigurationPropertyRector
+
+Rename a configuration property.
+
+:wrench: **configure it!**
+
+- class: [`Cambis\SilverstripeRector\Renaming\Rector\Class_\RenameConfigurationPropertyRector`](../rules/Renaming/Rector/Class_/RenameConfigurationPropertyRector.php)
+
+```diff
+ class Foo extends \SilverStripe\ORM\DataObject
+ {
+-    private static string $description = '';
++    private static string $class_description = '';
+ }
+
+-\SilverStripe\Config\Collections\MemoryConfigCollection::get('Foo', 'description');
+-Foo::config()->get('description');
++\SilverStripe\Config\Collections\MemoryConfigCollection::get('Foo', 'class_description');
++Foo::config()->get('class_description');
+```
+
+<br>
 
 ### RenameExtensionHookMethodRector
 
@@ -680,7 +703,7 @@ Migrate `ViewableData::cachedCall()` to `ViewableData::obj()`.
 
 Migrate `Controller::has_curr()` check to `Controller::curr() instanceof Controller`.
 
-- class: [`Cambis\SilverstripeRector\Silverstripe60\Rector\StaticCall\ControllerHasCurrToInstanceofRector`](../rules/Silverstripe60/Rector/StaticCall/ControllerHasCurrToInstanceOfRector.php)
+- class: [`Cambis\SilverstripeRector\Silverstripe60\Rector\StaticCall\ControllerHasCurrToInstanceofRector`](../rules/Silverstripe60/Rector/StaticCall/ControllerHasCurrToInstanceofRector.php)
 
 ```diff
 -if (\SilverStripe\Control\Controller::has_curr()) {

--- a/rules/Renaming/Rector/Class_/RenameConfigurationPropertyRector.php
+++ b/rules/Renaming/Rector/Class_/RenameConfigurationPropertyRector.php
@@ -1,0 +1,261 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\SilverstripeRector\Renaming\Rector\Class_;
+
+use Cambis\SilverstripeRector\NodeFactory\PropertyFactory;
+use Cambis\SilverstripeRector\Renaming\ValueObject\RenameConfigurationProperty;
+use InvalidArgumentException;
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\StaticPropertyFetch;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Property;
+use PhpParser\Node\VarLikeIdentifier;
+use PHPStan\Type\ObjectType;
+use Rector\Contract\Rector\ConfigurableRectorInterface;
+use Rector\NodeAnalyzer\ArgsAnalyzer;
+use Rector\PhpParser\Node\Value\ValueResolver;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use function is_string;
+
+/**
+ * @see \Cambis\SilverstripeRector\Tests\Renaming\Rector\Class_\RenameConfigurationPropertyRector\RenameConfigurationPropertyRectorTest
+ */
+final class RenameConfigurationPropertyRector extends AbstractRector implements ConfigurableRectorInterface, DocumentedRuleInterface
+{
+    /**
+     * @var list<RenameConfigurationProperty>
+     */
+    private array $renameProperties = [];
+
+    private bool $hasChanged = false;
+
+    public function __construct(
+        private readonly ArgsAnalyzer $argsAnalyzer,
+        private readonly PropertyFactory $propertyFactory,
+        private readonly ValueResolver $valueResolver
+    ) {
+    }
+
+    #[Override]
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Rename a configuration property.', [new ConfiguredCodeSample(
+            <<<'CODE_SAMPLE'
+class Foo extends \SilverStripe\ORM\DataObject
+{
+    private static string $description = '';
+}
+
+\SilverStripe\Config\Collections\MemoryConfigCollection::get('Foo', 'description');
+Foo::config()->get('description');
+CODE_SAMPLE
+            ,
+            <<<'CODE_SAMPLE'
+class Foo extends \SilverStripe\ORM\DataObject
+{
+    private static string $class_description = '';
+}
+
+\SilverStripe\Config\Collections\MemoryConfigCollection::get('Foo', 'class_description');
+Foo::config()->get('class_description');
+CODE_SAMPLE,
+            [new RenameConfigurationProperty('SilverStripe\ORM\DataObject', 'description', 'class_description')]
+        ),
+        ]);
+    }
+
+    #[Override]
+    public function getNodeTypes(): array
+    {
+        return [Class_::class,  MethodCall::class, StaticPropertyFetch::class];
+    }
+
+    /**
+     * @param Class_|MethodCall|StaticPropertyFetch $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($node instanceof MethodCall) {
+            return $this->refactorMethodCall($node);
+        }
+
+        if ($node instanceof StaticPropertyFetch) {
+            return $this->refactorStaticPropertyFetch($node);
+        }
+
+        $this->hasChanged = false;
+
+        foreach ($this->renameProperties as $renameConfigurationProperty) {
+            $this->renameProperty($node, $renameConfigurationProperty);
+        }
+
+        if (!$this->hasChanged) {
+            return null;
+        }
+
+        return $node;
+    }
+
+    public function configure(array $configuration): void
+    {
+        foreach ($configuration as $value) {
+            if (!$value instanceof RenameConfigurationProperty) {
+                throw new InvalidArgumentException(self::class . ' only accepts ' . RenameConfigurationProperty::class);
+            }
+        }
+
+        /** @var list<RenameConfigurationProperty> $configuration */
+        $this->renameProperties = $configuration;
+    }
+
+    private function refactorStaticPropertyFetch(StaticPropertyFetch $staticPropertyFetch): ?StaticPropertyFetch
+    {
+        foreach ($this->renameProperties as $renameProperty) {
+            if (!$this->isName($staticPropertyFetch, $renameProperty->oldPropertyName)) {
+                continue;
+            }
+
+            if (!$this->isObjectType($staticPropertyFetch->class, new ObjectType($renameProperty->extensibleClassName))) {
+                continue;
+            }
+
+            $staticPropertyFetch->name = new VarLikeIdentifier($renameProperty->newPropertyName);
+
+            return $staticPropertyFetch;
+        }
+
+        return null;
+    }
+
+    private function refactorMethodCall(MethodCall $methodCall): ?MethodCall
+    {
+        if ($this->argsAnalyzer->hasNamedArg($methodCall->getArgs())) {
+            return null;
+        }
+
+        if ($this->isObjectType($methodCall->var, new ObjectType('SilverStripe\Config\Collections\ConfigCollectionInterface'))) {
+            return $this->refactorConfigCollectionInterface($methodCall);
+        }
+
+        if ($this->isObjectType($methodCall->var, new ObjectType('SilverStripe\Core\Config\Config_ForClass'))) {
+            return $this->refactorConfigForClass($methodCall);
+        }
+
+        return null;
+    }
+
+    private function refactorConfigCollectionInterface(MethodCall $methodCall): ?MethodCall
+    {
+        if (!$this->isNames($methodCall->name, ['get', 'merge', 'remove', 'set'])) {
+            return null;
+        }
+
+        $classNameArg = $methodCall->getArgs()[0] ?? null;
+        $propertyNameArg = $methodCall->getArgs()[1] ?? null;
+
+        if (!$classNameArg instanceof Arg || !$propertyNameArg instanceof Arg) {
+            return null;
+        }
+
+        $className = $this->valueResolver->getValue($classNameArg, true);
+        $propertyName = $this->valueResolver->getValue($propertyNameArg);
+
+        if (!is_string($className)) {
+            return null;
+        }
+
+        foreach ($this->renameProperties as $renameProperty) {
+            if ((new ObjectType($renameProperty->extensibleClassName))->isSuperTypeOf(new ObjectType($className))->no()) {
+                continue;
+            }
+
+            if ($propertyName !== $renameProperty->oldPropertyName) {
+                continue;
+            }
+
+            $args = [...$methodCall->getArgs()];
+            $args[1] = $this->nodeFactory->createArg($renameProperty->newPropertyName);
+
+            return $this->nodeFactory->createMethodCall(
+                $methodCall->var,
+                $this->getName($methodCall->name) ?? 'get',
+                $args
+            );
+        }
+
+        return null;
+    }
+
+    private function refactorConfigForClass(MethodCall $methodCall): ?MethodCall
+    {
+        if (!$this->isNames($methodCall->name, ['get', 'merge', 'remove', 'set', 'uninherited'])) {
+            return null;
+        }
+
+        $propertyNameArg = $methodCall->getArgs()[0] ?? null;
+
+        if (!$propertyNameArg instanceof Arg) {
+            return null;
+        }
+
+        // Attempt to resolve the type of the var
+        if (!$methodCall->var instanceof StaticCall && !$methodCall->var instanceof MethodCall) {
+            return null;
+        }
+
+        $type = $methodCall->var instanceof StaticCall ? $this->getType($methodCall->var->class) : $this->getType($methodCall->var->var);
+        $propertyName = $this->valueResolver->getValue($propertyNameArg);
+
+        foreach ($this->renameProperties as $renameProperty) {
+            if ((new ObjectType($renameProperty->extensibleClassName))->isSuperTypeOf($type)->no()) {
+                continue;
+            }
+
+            if ($propertyName !== $renameProperty->oldPropertyName) {
+                continue;
+            }
+
+            $args = [...$methodCall->getArgs()];
+            $args[0] = $this->nodeFactory->createArg($renameProperty->newPropertyName);
+
+            return $this->nodeFactory->createMethodCall(
+                $methodCall->var,
+                $this->getName($methodCall->name) ?? 'get',
+                $args
+            );
+        }
+
+        return null;
+    }
+
+    private function renameProperty(Class_ $class, RenameConfigurationProperty $renameConfigurationProperty): void
+    {
+        if (!$this->isObjectType($class, new ObjectType($renameConfigurationProperty->extensibleClassName))) {
+            return;
+        }
+
+        $property = $this->propertyFactory->findConfigurationProperty($class, $renameConfigurationProperty->oldPropertyName);
+
+        if (!$property instanceof Property) {
+            return;
+        }
+
+        $newProperty = $this->propertyFactory->findConfigurationProperty($class, $renameConfigurationProperty->newPropertyName);
+
+        if ($newProperty instanceof Property) {
+            return;
+        }
+
+        $property->props[0]->name = new VarLikeIdentifier($renameConfigurationProperty->newPropertyName);
+        $this->hasChanged = true;
+    }
+}

--- a/rules/Renaming/ValueObject/RenameConfigurationProperty.php
+++ b/rules/Renaming/ValueObject/RenameConfigurationProperty.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\SilverstripeRector\Renaming\ValueObject;
+
+use Rector\Validation\RectorAssert;
+
+final readonly class RenameConfigurationProperty
+{
+    public function __construct(
+        public string $extensibleClassName,
+        public string $oldPropertyName,
+        public string $newPropertyName
+    ) {
+        RectorAssert::className($extensibleClassName);
+        RectorAssert::propertyName($oldPropertyName);
+        RectorAssert::propertyName($newPropertyName);
+    }
+}

--- a/src/NodeFactory/PropertyFactory.php
+++ b/src/NodeFactory/PropertyFactory.php
@@ -12,6 +12,7 @@ use PHPStan\Type\IntegerType;
 use PHPStan\Type\StringType;
 use Rector\NodeManipulator\ClassInsertManipulator;
 use Rector\PhpParser\Node\NodeFactory;
+use function str_contains;
 
 final readonly class PropertyFactory
 {
@@ -34,6 +35,10 @@ final readonly class PropertyFactory
         }
 
         if (!$property->isStatic()) {
+            return null;
+        }
+
+        if (str_contains($property->getDocComment()?->getText() ?? '', '@internal')) {
             return null;
         }
 

--- a/stubs/SilverStripe/Core/Config/Config_ForClass.php
+++ b/stubs/SilverStripe/Core/Config/Config_ForClass.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SilverStripe\Core\Config;
+
+use function class_exists;
+
+if (class_exists('SilverStripe\Core\Config\Config_ForClass')) {
+    return;
+}
+
+class Config_ForClass
+{
+}

--- a/stubs/SilverStripe/Core/Config/Configurable.php
+++ b/stubs/SilverStripe/Core/Config/Configurable.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SilverStripe\Core\Config;
 
 use function trait_exists;
@@ -10,4 +12,8 @@ if (trait_exists('SilverStripe\Core\Config\Configurable')) {
 
 trait Configurable
 {
+    public static function config(): Config_ForClass
+    {
+        return new Config_ForClass();
+    }
 }

--- a/tests/rules/Renaming/Rector/Class_/RenameConfigurationPropertyRector/Fixture/rename_config_collection.php.inc
+++ b/tests/rules/Renaming/Rector/Class_/RenameConfigurationPropertyRector/Fixture/rename_config_collection.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\Renaming\Rector\Class_\RenameConfigurationPropertyRector\Fixture;
+
+use SilverStripe\Config\Collections\MemoryConfigCollection;
+
+$collection = new MemoryConfigCollection();
+
+$collection->get('Cambis\SilverstripeRector\Tests\Renaming\Rector\Class_\RenameConfigurationPropertyRector\Source\Foo', 'description');
+$collection->merge('Cambis\SilverstripeRector\Tests\Renaming\Rector\Class_\RenameConfigurationPropertyRector\Source\Foo', 'description', ['']);
+$collection->set('Cambis\SilverstripeRector\Tests\Renaming\Rector\Class_\RenameConfigurationPropertyRector\Source\Foo', 'description', '');
+$collection->remove('Cambis\SilverstripeRector\Tests\Renaming\Rector\Class_\RenameConfigurationPropertyRector\Source\Foo', 'description');
+
+?>
+-----
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\Renaming\Rector\Class_\RenameConfigurationPropertyRector\Fixture;
+
+use SilverStripe\Config\Collections\MemoryConfigCollection;
+
+$collection = new MemoryConfigCollection();
+
+$collection->get('Cambis\SilverstripeRector\Tests\Renaming\Rector\Class_\RenameConfigurationPropertyRector\Source\Foo', 'class_description');
+$collection->merge('Cambis\SilverstripeRector\Tests\Renaming\Rector\Class_\RenameConfigurationPropertyRector\Source\Foo', 'class_description', ['']);
+$collection->set('Cambis\SilverstripeRector\Tests\Renaming\Rector\Class_\RenameConfigurationPropertyRector\Source\Foo', 'class_description', '');
+$collection->remove('Cambis\SilverstripeRector\Tests\Renaming\Rector\Class_\RenameConfigurationPropertyRector\Source\Foo', 'class_description');
+
+?>

--- a/tests/rules/Renaming/Rector/Class_/RenameConfigurationPropertyRector/Fixture/rename_config_for_class.php.inc
+++ b/tests/rules/Renaming/Rector/Class_/RenameConfigurationPropertyRector/Fixture/rename_config_for_class.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\Renaming\Rector\Class_\RenameConfigurationPropertyRector\Fixture;
+
+use Cambis\SilverstripeRector\Tests\Renaming\Rector\Class_\RenameConfigurationPropertyRector\Source\Foo;
+
+Foo::config()->get('description', true);
+Foo::config()->set('description', '');
+Foo::config()->merge('description', ['']);
+Foo::config()->uninherited('description');
+Foo::config()->remove('description');
+
+?>
+-----
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\Renaming\Rector\Class_\RenameConfigurationPropertyRector\Fixture;
+
+use Cambis\SilverstripeRector\Tests\Renaming\Rector\Class_\RenameConfigurationPropertyRector\Source\Foo;
+
+Foo::config()->get('class_description', true);
+Foo::config()->set('class_description', '');
+Foo::config()->merge('class_description', ['']);
+Foo::config()->uninherited('class_description');
+Foo::config()->remove('class_description');
+
+?>

--- a/tests/rules/Renaming/Rector/Class_/RenameConfigurationPropertyRector/Fixture/rename_configuration_property.php.inc
+++ b/tests/rules/Renaming/Rector/Class_/RenameConfigurationPropertyRector/Fixture/rename_configuration_property.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\Renaming\Rector\Class_\RenameConfigurationPropertyRector\Fixture;
+
+class RenameConfigurationProperty extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+{
+    private static string $description = '';
+
+    public function getTitle(): string
+    {
+        return $this->Description ?? '';
+    }
+
+    public function getNiceDescription(): string
+    {
+        return $this->config()->get('description');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\Renaming\Rector\Class_\RenameConfigurationPropertyRector\Fixture;
+
+class RenameConfigurationProperty extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+{
+    private static string $class_description = '';
+
+    public function getTitle(): string
+    {
+        return $this->Description ?? '';
+    }
+
+    public function getNiceDescription(): string
+    {
+        return $this->config()->get('class_description');
+    }
+}
+
+?>

--- a/tests/rules/Renaming/Rector/Class_/RenameConfigurationPropertyRector/Fixture/rename_non_configuration_property.php.inc
+++ b/tests/rules/Renaming/Rector/Class_/RenameConfigurationPropertyRector/Fixture/rename_non_configuration_property.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\Renaming\Rector\Class_\RenameConfigurationPropertyRector\Fixture;
+
+class RenameNonConfigurationProperty extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+{
+    /**
+     * @internal
+     */
+    private static string $description = '';
+}

--- a/tests/rules/Renaming/Rector/Class_/RenameConfigurationPropertyRector/RenameConfigurationPropertyRectorTest.php
+++ b/tests/rules/Renaming/Rector/Class_/RenameConfigurationPropertyRector/RenameConfigurationPropertyRectorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\SilverstripeRector\Tests\Renaming\Rector\Class_\RenameConfigurationPropertyRector;
+
+use Cambis\SilverstripeRector\Testing\PHPUnit\AbstractSilverstripeRectorTestCase;
+use Iterator;
+use Override;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class RenameConfigurationPropertyRectorTest extends AbstractSilverstripeRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    #[Override]
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/rules/Renaming/Rector/Class_/RenameConfigurationPropertyRector/Source/Foo.php
+++ b/tests/rules/Renaming/Rector/Class_/RenameConfigurationPropertyRector/Source/Foo.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\Renaming\Rector\Class_\RenameConfigurationPropertyRector\Source;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+final class Foo extends DataObject implements TestOnly
+{
+}

--- a/tests/rules/Renaming/Rector/Class_/RenameConfigurationPropertyRector/config/configured_rule.php
+++ b/tests/rules/Renaming/Rector/Class_/RenameConfigurationPropertyRector/config/configured_rule.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Cambis\SilverstripeRector\Renaming\Rector\Class_\RenameConfigurationPropertyRector;
+use Cambis\SilverstripeRector\Renaming\ValueObject\RenameConfigurationProperty;
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withConfiguredRule(
+        RenameConfigurationPropertyRector::class,
+        [
+            new RenameConfigurationProperty('SilverStripe\ORM\DataObject', 'description', 'class_description'),
+        ]
+    );


### PR DESCRIPTION
## Description ✍️

- Add a rector to specifically rename configuration properties

## DoD checklist ✅

- [x] I have performed a self-review of my code
- [x] My code adheres to the [coding standards](https://github.com/Cambis/silverstripe-rector/blob/main/CONTRIBUTING.md#coding-standards-️)
- [x] My commit messages adhere to the [commit standards](https://github.com/Cambis/silverstripe-rector/blob/main/CONTRIBUTING.md#commit-standards-️).
- [x] My code has been [tested](https://github.com/Cambis/silverstripe-rector/blob/main/CONTRIBUTING.md#testing-).
- [x] I have added a [changeset](https://github.com/Cambis/silverstripe-rector/blob/main/CONTRIBUTING.md#making-a-pull-request-).
