### PR TITLE
Silverstripe 6.1

### DIFF
--- a/.changeset/five-feet-kneel.md
+++ b/.changeset/five-feet-kneel.md
@@ -1,0 +1,5 @@
+---
+"@cambis/silverstripe-rector": minor
+---
+
+Add Silverstripe 6.1; Bump minimum rector version to 2.1

--- a/build/composer-php-74.json
+++ b/build/composer-php-74.json
@@ -9,8 +9,8 @@
   ],
   "require": {
       "php": "^7.4 || ^8.0",
-      "cambis/silverstan": "^2.0.1",
-      "rector/rector": "^2.0"
+      "cambis/silverstan": "^2.1",
+      "rector/rector": "^2.1"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
     ],
     "require": {
         "php": "^8.3",
-        "cambis/silverstan": "^2.0.1",
-        "rector/rector": "^2.0"
+        "cambis/silverstan": "^2.1",
+        "rector/rector": "^2.1"
     },
     "require-dev": {
         "cweagans/composer-patches": "^1.7",
@@ -21,7 +21,7 @@
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
-        "phpunit/phpunit": "^12.1",
+        "phpunit/phpunit": "~12.1.0",
         "slevomat/coding-standard": "^8.14",
         "symplify/easy-coding-standard": "^12.0",
         "symplify/phpstan-extensions": "^12.0",

--- a/config/set/code-quality.php
+++ b/config/set/code-quality.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Cambis\SilverstripeRector\CodeQuality\Rector\New_\InjectableNewInstanceToCreateRector;
-use Cambis\SilverstripeRector\CodeQuality\Rector\StaticCall\DataObjectGetByIDCachedToUncachedRector;
 use Cambis\SilverstripeRector\CodeQuality\Rector\StaticPropertyFetch\StaticPropertyFetchToConfigGetRector;
 use Rector\Config\RectorConfig;
 use Rector\Transform\Rector\Assign\PropertyFetchToMethodCallRector;
@@ -11,7 +10,6 @@ use Rector\Transform\ValueObject\PropertyFetchToMethodCall;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rules([
-        DataObjectGetByIDCachedToUncachedRector::class,
         InjectableNewInstanceToCreateRector::class,
         StaticPropertyFetchToConfigGetRector::class,
     ]);

--- a/config/set/level/up-to-silverstripe61.php
+++ b/config/set/level/up-to-silverstripe61.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Cambis\SilverstripeRector\Set\ValueObject\SilverstripeLevelSetList;
+use Cambis\SilverstripeRector\Set\ValueObject\SilverstripeSetList;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([SilverstripeSetList::SILVERSTRIPE_61, SilverstripeLevelSetList::UP_TO_SILVERSTRIPE_60]);
+};

--- a/config/set/silverstripe61.php
+++ b/config/set/silverstripe61.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Cambis\SilverstripeRector\Configuration\SilverstripeOption;
+use Cambis\SilverstripeRector\Silverstripe61\Rector\StaticCall\DataObjectGetByIdCachedRector;
+use Cambis\SilverstripeRector\Silverstripe61\Rector\StaticCall\DataObjectGetOneCachedRector;
+use Rector\Config\RectorConfig;
+
+// https://docs.silverstripe.org/en/6/changelogs/6.1.0/
+return static function (RectorConfig $rectorConfig): void {
+    // Add Silverstripe53 PHPStan patch
+    $rectorConfig->phpstanConfigs([
+        SilverstripeOption::PHPSTAN_FOR_RECTOR_PATH,
+        SilverstripeOption::PHPSTAN_FOR_RECTOR_SILVERSTRIPE_53_PATH,
+    ]);
+
+    $rectorConfig->import(__DIR__ . '/../config.php');
+
+    // https://github.com/silverstripe/silverstripe-framework/issues/11767
+    $rectorConfig->rules([
+        DataObjectGetByIdCachedRector::class,
+        DataObjectGetOneCachedRector::class,
+    ]);
+};

--- a/config/set/silverstripe61.php
+++ b/config/set/silverstripe61.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Cambis\SilverstripeRector\Configuration\SilverstripeOption;
+use Cambis\SilverstripeRector\Silverstripe61\Rector\StaticCall\DataObjectDeleteByIdCachedRector;
 use Cambis\SilverstripeRector\Silverstripe61\Rector\StaticCall\DataObjectGetByIdCachedRector;
 use Cambis\SilverstripeRector\Silverstripe61\Rector\StaticCall\DataObjectGetOneCachedRector;
 use Rector\Config\RectorConfig;
@@ -20,6 +21,7 @@ return static function (RectorConfig $rectorConfig): void {
     // https://github.com/silverstripe/silverstripe-framework/issues/11767
     $rectorConfig->rules([
         DataObjectGetByIdCachedRector::class,
+        DataObjectDeleteByIdCachedRector::class,
         DataObjectGetOneCachedRector::class,
     ]);
 };

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 33 Rules Overview
+# 35 Rules Overview
 
 <br>
 
@@ -21,6 +21,8 @@
 - [Silverstripe54](#silverstripe54) (4)
 
 - [Silverstripe60](#silverstripe60) (1)
+
+- [Silverstripe61](#silverstripe61) (2)
 
 <br>
 
@@ -711,6 +713,40 @@ Migrate `Controller::has_curr()` check to `Controller::curr() instanceof Control
 +if (\SilverStripe\Control\Controller::curr() instanceof \SilverStripe\Control\Controller) {
     // ...
  }
+```
+
+<br>
+
+## Silverstripe61
+
+### DataObjectGetByIdCachedRector
+
+Migrate `DataObject::get_by_id()` call to `DataObject::get()->setUseCache()->byID()`.
+
+- class: [`Cambis\SilverstripeRector\Silverstripe61\Rector\StaticCall\DataObjectGetByIdCachedRector`](../rules/Silverstripe61/Rector/StaticCall/DataObjectGetByIdCachedRector.php)
+
+```diff
+-Foo::get_by_id(1);
++Foo::get()->setUseCache(true)->byId(1);
+
+-\SilverStripe\ORM\DataObject::get_by_id(Foo::class, 1);
++Foo::get()->setUseCache(true)->byId(1);
+```
+
+<br>
+
+### DataObjectGetOneCachedRector
+
+Migrate `DataObject::get_one()` call to `DataObject::get()->setUseCache()->first()`.
+
+- class: [`Cambis\SilverstripeRector\Silverstripe61\Rector\StaticCall\DataObjectGetOneCachedRector`](../rules/Silverstripe61/Rector/StaticCall/DataObjectGetOneCachedRector.php)
+
+```diff
+-Foo::get_one();
++Foo::get()->setUseCache(true)->first();
+
+-\SilverStripe\ORM\DataObject::get_one(Foo::class);
++Foo::get()->setUseCache(true)->first();
 ```
 
 <br>

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 34 Rules Overview
+# 35 Rules Overview
 
 <br>
 
@@ -22,7 +22,7 @@
 
 - [Silverstripe60](#silverstripe60) (1)
 
-- [Silverstripe61](#silverstripe61) (2)
+- [Silverstripe61](#silverstripe61) (3)
 
 <br>
 
@@ -705,6 +705,19 @@ Migrate `Controller::has_curr()` check to `Controller::curr() instanceof Control
 <br>
 
 ## Silverstripe61
+
+### DataObjectDeleteByIdCachedRector
+
+Migrate `DataObject::delete_by_id()` to `DataObject::get()->setUseCache()->byID()->delete()`.
+
+- class: [`Cambis\SilverstripeRector\Silverstripe61\Rector\StaticCall\DataObjectDeleteByIdCachedRector`](../rules/Silverstripe61/Rector/StaticCall/DataObjectDeleteByIdCachedRector.php)
+
+```diff
+-\SilverStripe\ORM\DataObject::delete_by_id(Foo::class, 1);
++Foo::get()->setUseCache(true)->byID(1)?->delete();
+```
+
+<br>
 
 ### DataObjectGetByIdCachedRector
 

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -727,10 +727,10 @@ Migrate `DataObject::get_by_id()` to `DataObject::get()->setUseCache()->byID()`.
 
 ```diff
 -Foo::get_by_id(1);
-+Foo::get()->setUseCache(true)->byId(1);
++Foo::get()->setUseCache(true)->byID(1);
 
 -\SilverStripe\ORM\DataObject::get_by_id(Foo::class, 1);
-+Foo::get()->setUseCache(true)->byId(1);
++Foo::get()->setUseCache(true)->byID(1);
 ```
 
 <br>

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -708,7 +708,7 @@ Migrate `Controller::has_curr()` check to `Controller::curr() instanceof Control
 
 ### DataObjectGetByIdCachedRector
 
-Migrate `DataObject::get_by_id()` call to `DataObject::get()->setUseCache()->byID()`.
+Migrate `DataObject::get_by_id()` to `DataObject::get()->setUseCache()->byID()`.
 
 - class: [`Cambis\SilverstripeRector\Silverstripe61\Rector\StaticCall\DataObjectGetByIdCachedRector`](../rules/Silverstripe61/Rector/StaticCall/DataObjectGetByIdCachedRector.php)
 
@@ -724,7 +724,7 @@ Migrate `DataObject::get_by_id()` call to `DataObject::get()->setUseCache()->byI
 
 ### DataObjectGetOneCachedRector
 
-Migrate `DataObject::get_one()` call to `DataObject::get()->setUseCache()->first()`.
+Migrate `DataObject::get_one()` to `DataObject::get()->setUseCache()->first()`.
 
 - class: [`Cambis\SilverstripeRector\Silverstripe61\Rector\StaticCall\DataObjectGetOneCachedRector`](../rules/Silverstripe61/Rector/StaticCall/DataObjectGetOneCachedRector.php)
 

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,10 +1,10 @@
-# 35 Rules Overview
+# 34 Rules Overview
 
 <br>
 
 ## Categories
 
-- [CodeQuality](#codequality) (3)
+- [CodeQuality](#codequality) (2)
 
 - [LinkField](#linkfield) (5)
 
@@ -27,19 +27,6 @@
 <br>
 
 ## CodeQuality
-
-### DataObjectGetByIDCachedToUncachedRector
-
-Change `DataObject::get_by_id()` to use `DataObject::get()->byID()` instead.
-
-- class: [`Cambis\SilverstripeRector\CodeQuality\Rector\StaticCall\DataObjectGetByIDCachedToUncachedRector`](../rules/CodeQuality/Rector/StaticCall/DataObjectGetByIDCachedToUncachedRector.php)
-
-```diff
--$foo = \SilverStripe\Assets\File::get_by_id(1);
-+$foo = \SilverStripe\Assets\File::get()->byID(1);
-```
-
-<br>
 
 ### InjectableNewInstanceToCreateRector
 

--- a/patches/rector-rector-src-testing-phpunit-abstractrectortestcase-php.patch
+++ b/patches/rector-rector-src-testing-phpunit-abstractrectortestcase-php.patch
@@ -1,11 +1,11 @@
 --- /dev/null
 +++ ../src/Testing/PHPUnit/AbstractRectorTestCase.php
-@@ -135,6 +135,8 @@
+@@ -123,6 +123,8 @@
          }
          // write temp file
          FileSystem::write($inputFilePath, $inputFileContents, null);
 +        $classManifest = self::getContainer()->has('Cambis\Silverstan\ClassManifest\ClassManifest') ? $this->make('Cambis\Silverstan\ClassManifest\ClassManifest') : null;
 +        \Cambis\SilverstripeRector\Testing\Fixture\FixtureManifestUpdater::addInputFileToClassManifest($inputFilePath, $classManifest);
-         $this->doTestFileMatchesExpectedContent($inputFilePath, $inputFileContents, $expectedFileContents, $fixtureFilePath);
+         $this->doTestFileMatchesExpectedContent($inputFilePath, $inputFileContents, $expectedFileContents, $fixtureFilePath, $includeFixtureDirectoryAsSource);
      }
-     private function forgetRectorsRules() : void
+     protected function doTestFileExpectingWarningAboutRuleApplied(string $fixtureFilePath, string $expectedRuleApplied) : void

--- a/rules/CodeQuality/Rector/StaticCall/DataObjectGetByIDCachedToUncachedRector.php
+++ b/rules/CodeQuality/Rector/StaticCall/DataObjectGetByIDCachedToUncachedRector.php
@@ -16,7 +16,10 @@ use function count;
 use function is_string;
 
 /**
+ * @deprecated since 2.1.0
+ *
  * @changelog https://github.com/silverstripe/silverstripe-framework/issues/5976
+ *
  * @see \Cambis\SilverstripeRector\Tests\CodeQuality\Rector\StaticCall\DataObjectGetByIDCachedToUncachedRector\DataObjectGetByIDCachedToUncachedRectorTest
  */
 final class DataObjectGetByIDCachedToUncachedRector extends AbstractRector implements DocumentedRuleInterface

--- a/rules/Silverstripe61/NodeAnalyser/DataObjectArgsAnalyser.php
+++ b/rules/Silverstripe61/NodeAnalyser/DataObjectArgsAnalyser.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\SilverstripeRector\Silverstripe61\NodeAnalyser;
+
+use PhpParser\Node\Arg;
+use PHPStan\Reflection\ReflectionProvider;
+use Rector\PhpParser\Node\Value\ValueResolver;
+use function is_bool;
+use function is_numeric;
+use function is_string;
+
+final readonly class DataObjectArgsAnalyser
+{
+    public function __construct(
+        private ReflectionProvider $reflectionProvider,
+        private ValueResolver $valueResolver
+    ) {
+    }
+
+    /**
+     * Get the class name value from `DataObject::get_by_id()` or `DataObject::get_one()`.
+     *
+     * @param Arg[] $args
+     */
+    public function getDataClassNameFromArgs(array $args): ?string
+    {
+        $classNameArg = $args[0] ?? null;
+
+        if (!$classNameArg instanceof Arg) {
+            return null;
+        }
+
+        $classNameArgValue = $this->valueResolver->getValue($classNameArg);
+
+        if (!is_string($classNameArgValue)) {
+            return null;
+        }
+
+        if (!$this->reflectionProvider->hasClass($classNameArgValue)) {
+            return null;
+        }
+
+        return $classNameArgValue;
+    }
+
+    /**
+     * Get the `id` argument from `DataObject::get_by_id()`.
+     *
+     * @param Arg[] $args
+     */
+    public function getIdFromArgs(array $args): ?Arg
+    {
+        foreach ($args as $arg) {
+            if (!is_numeric($this->valueResolver->getValue($arg))) {
+                continue;
+            }
+
+            return $arg;
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the `cached` argument from `DataObject::get_by_id()` or `DataObject::get_one()`.
+     *
+     * @param Arg[] $args
+     */
+    public function getIsCachedFromArgs(array $args): ?Arg
+    {
+        foreach ($args as $arg) {
+            if (!is_bool($this->valueResolver->getValue($arg))) {
+                continue;
+            }
+
+            return $arg;
+        }
+
+        return null;
+    }
+}

--- a/rules/Silverstripe61/Rector/StaticCall/DataObjectDeleteByIdCachedRector.php
+++ b/rules/Silverstripe61/Rector/StaticCall/DataObjectDeleteByIdCachedRector.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\SilverstripeRector\Silverstripe61\Rector\StaticCall;
+
+use Cambis\SilverstripeRector\Silverstripe61\NodeAnalyser\DataObjectArgsAnalyser;
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\NullsafeMethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Type\ObjectType;
+use Rector\NodeAnalyzer\ArgsAnalyzer;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectDeleteByIdCachedRector\DataObjectDeleteByIdCachedRectorTest
+ */
+final class DataObjectDeleteByIdCachedRector extends AbstractRector implements DocumentedRuleInterface
+{
+    public function __construct(
+        private readonly ArgsAnalyzer $argsAnalyzer,
+        private readonly DataObjectArgsAnalyser $dataObjectArgsAnalyser
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Migrate `DataObject::delete_by_id()` to `DataObject::get()->setUseCache()->byID()->delete()`.', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+\SilverStripe\ORM\DataObject::delete_by_id(Foo::class, 1);
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+Foo::get()->setUseCache(true)->byID(1)?->delete();
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [StaticCall::class];
+    }
+
+    /**
+     * @param StaticCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        // Not supporting named arguments
+        if ($this->argsAnalyzer->hasNamedArg($node->getArgs())) {
+            return null;
+        }
+
+        // Can't do anything if no args were supplied
+        if ($node->getArgs() === []) {
+            return null;
+        }
+
+        if (!$this->isObjectType($node->class, new ObjectType('SilverStripe\ORM\DataObject'))) {
+            return null;
+        }
+
+        if (!$this->isName($node->name, 'delete_by_id')) {
+            return null;
+        }
+
+        $dataClass = $this->dataObjectArgsAnalyser->getDataClassNameFromArgs($node->getArgs()) ?? '';
+
+        if ($dataClass === '') {
+            return null;
+        }
+
+        $id = $this->dataObjectArgsAnalyser->getIdFromArgs($node->getArgs());
+
+        // This shouldn't happen in reality but we'll fail silently just in case
+        if (!$id instanceof Arg) {
+            return null;
+        }
+
+        $dataListCall = $this->nodeFactory->createStaticCall($dataClass, 'get');
+        $dataListCall = $this->nodeFactory->createMethodCall($dataListCall, 'setUseCache', [true]);
+        $dataListCall = $this->nodeFactory->createMethodCall($dataListCall, 'byID', [$id]);
+
+        return new NullsafeMethodCall($dataListCall, 'delete');
+    }
+}

--- a/rules/Silverstripe61/Rector/StaticCall/DataObjectGetByIdCachedRector.php
+++ b/rules/Silverstripe61/Rector/StaticCall/DataObjectGetByIdCachedRector.php
@@ -42,9 +42,9 @@ Foo::get_by_id(1);
 CODE_SAMPLE
                 ,
                 <<<'CODE_SAMPLE'
-Foo::get()->setUseCache(true)->byId(1);
+Foo::get()->setUseCache(true)->byID(1);
 
-Foo::get()->setUseCache(true)->byId(1);
+Foo::get()->setUseCache(true)->byID(1);
 CODE_SAMPLE
             ),
         ]);

--- a/rules/Silverstripe61/Rector/StaticCall/DataObjectGetByIdCachedRector.php
+++ b/rules/Silverstripe61/Rector/StaticCall/DataObjectGetByIdCachedRector.php
@@ -33,7 +33,7 @@ final class DataObjectGetByIdCachedRector extends AbstractRector implements Docu
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Migrate `DataObject::get_by_id()` call to `DataObject::get()->setUseCache()->byID()`.', [
+        return new RuleDefinition('Migrate `DataObject::get_by_id()` to `DataObject::get()->setUseCache()->byID()`.', [
             new CodeSample(
                 <<<'CODE_SAMPLE'
 Foo::get_by_id(1);

--- a/rules/Silverstripe61/Rector/StaticCall/DataObjectGetByIdCachedRector.php
+++ b/rules/Silverstripe61/Rector/StaticCall/DataObjectGetByIdCachedRector.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\SilverstripeRector\Silverstripe61\Rector\StaticCall;
+
+use Cambis\SilverstripeRector\Silverstripe61\NodeAnalyser\DataObjectArgsAnalyser;
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
+use PHPStan\Type\ObjectType;
+use Rector\NodeAnalyzer\ArgsAnalyzer;
+use Rector\PhpParser\Node\Value\ValueResolver;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @changelog https://github.com/silverstripe/silverstripe-framework/issues/11767
+ *
+ * @see \Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetByIdCachedRector\DataObjectGetByIdCachedRectorTest
+ */
+final class DataObjectGetByIdCachedRector extends AbstractRector implements DocumentedRuleInterface
+{
+    public function __construct(
+        private readonly ArgsAnalyzer $argsAnalyzer,
+        private readonly DataObjectArgsAnalyser $dataObjectArgsAnalyser,
+        private readonly ValueResolver $valueResolver
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Migrate `DataObject::get_by_id()` call to `DataObject::get()->setUseCache()->byID()`.', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+Foo::get_by_id(1);
+
+\SilverStripe\ORM\DataObject::get_by_id(Foo::class, 1);
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+Foo::get()->setUseCache(true)->byId(1);
+
+Foo::get()->setUseCache(true)->byId(1);
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [StaticCall::class];
+    }
+
+    /**
+     * @param StaticCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        // Not supporting named arguments
+        if ($this->argsAnalyzer->hasNamedArg($node->getArgs())) {
+            return null;
+        }
+
+        // Can't do anything if no args were supplied
+        if ($node->getArgs() === []) {
+            return null;
+        }
+
+        if (!$this->isObjectType($node->class, new ObjectType('SilverStripe\ORM\DataObject'))) {
+            return null;
+        }
+
+        if (!$this->isName($node->name, 'get_by_id')) {
+            return null;
+        }
+
+        $dataClass = $this->dataObjectArgsAnalyser->getDataClassNameFromArgs($node->getArgs()) ?? $this->getName($node->class);
+
+        if ($dataClass === null || $dataClass === '') {
+            return null;
+        }
+
+        $id = $this->dataObjectArgsAnalyser->getIdFromArgs($node->getArgs());
+
+        // This shouldn't happen in reality but we'll fail silently just in case
+        if (!$id instanceof Arg) {
+            return null;
+        }
+
+        // Call to `DataObject::get()`
+        $dataListCall = $this->nodeFactory->createStaticCall($dataClass, 'get');
+
+        $isCachedArg = $this->dataObjectArgsAnalyser->getIsCachedFromArgs($node->getArgs());
+        $isCached = false;
+
+        if (!$isCachedArg instanceof Arg) {
+            $isCached = true;
+        } elseif ($isCachedArg->value instanceof Variable) {
+            $isCached = $isCachedArg;
+        } else {
+            $isCached = $this->valueResolver->getValue($isCachedArg);
+        }
+
+        // Add the call to `DataList::setUseCache()`, skip if the original argument was a constant `false`
+        if ($isCached !== false) {
+            $dataListCall = $this->nodeFactory->createMethodCall($dataListCall, 'setUseCache', [$isCached]);
+        }
+
+        return $this->nodeFactory->createMethodCall($dataListCall, 'byID', [$id]);
+    }
+}

--- a/rules/Silverstripe61/Rector/StaticCall/DataObjectGetOneCachedRector.php
+++ b/rules/Silverstripe61/Rector/StaticCall/DataObjectGetOneCachedRector.php
@@ -33,7 +33,7 @@ final class DataObjectGetOneCachedRector extends AbstractRector implements Docum
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Migrate `DataObject::get_one()` call to `DataObject::get()->setUseCache()->first()`.', [
+        return new RuleDefinition('Migrate `DataObject::get_one()` to `DataObject::get()->setUseCache()->first()`.', [
             new CodeSample(
                 <<<'CODE_SAMPLE'
 Foo::get_one();

--- a/rules/Silverstripe61/Rector/StaticCall/DataObjectGetOneCachedRector.php
+++ b/rules/Silverstripe61/Rector/StaticCall/DataObjectGetOneCachedRector.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\SilverstripeRector\Silverstripe61\Rector\StaticCall;
+
+use Cambis\SilverstripeRector\Silverstripe61\NodeAnalyser\DataObjectArgsAnalyser;
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
+use PHPStan\Type\ObjectType;
+use Rector\NodeAnalyzer\ArgsAnalyzer;
+use Rector\PhpParser\Node\Value\ValueResolver;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @changelog https://github.com/silverstripe/silverstripe-framework/issues/11767
+ *
+ * @see \Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetOneCachedRector\DataObjectGetOneCachedRectorTest
+ */
+final class DataObjectGetOneCachedRector extends AbstractRector implements DocumentedRuleInterface
+{
+    public function __construct(
+        private readonly ArgsAnalyzer $argsAnalyzer,
+        private readonly DataObjectArgsAnalyser $dataObjectArgsAnalyser,
+        private readonly ValueResolver $valueResolver
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Migrate `DataObject::get_one()` call to `DataObject::get()->setUseCache()->first()`.', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+Foo::get_one();
+
+\SilverStripe\ORM\DataObject::get_one(Foo::class);
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+Foo::get()->setUseCache(true)->first();
+
+Foo::get()->setUseCache(true)->first();
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [StaticCall::class];
+    }
+
+    /**
+     * @param StaticCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        // Not supporting named arguments
+        if ($this->argsAnalyzer->hasNamedArg($node->getArgs())) {
+            return null;
+        }
+
+        if (!$this->isObjectType($node->class, new ObjectType('SilverStripe\ORM\DataObject'))) {
+            return null;
+        }
+
+        if (!$this->isName($node->name, 'get_one')) {
+            return null;
+        }
+
+        $dataClass = $this->dataObjectArgsAnalyser->getDataClassNameFromArgs($node->getArgs()) ?? $this->getName($node->class);
+
+        if ($dataClass === null || $dataClass === '') {
+            return null;
+        }
+
+        // Call to `DataObject::get()`
+        $dataListCall = $this->nodeFactory->createStaticCall($dataClass, 'get');
+
+        $isCachedArg = $this->dataObjectArgsAnalyser->getIsCachedFromArgs($node->getArgs());
+        $isCached = false;
+
+        if (!$isCachedArg instanceof Arg) {
+            $isCached = true;
+        } elseif ($isCachedArg->value instanceof Variable) {
+            $isCached = $isCachedArg;
+        } else {
+            $isCached = $this->valueResolver->getValue($isCachedArg);
+        }
+
+        // Add the call to `DataList::setUseCache()`, skip if the original argument was a constant `false`
+        if ($isCached !== false) {
+            $dataListCall = $this->nodeFactory->createMethodCall($dataListCall, 'setUseCache', [$isCached]);
+        }
+
+        return $this->nodeFactory->createMethodCall($dataListCall, 'first', []);
+    }
+}

--- a/src/Set/ValueObject/SilverstripeLevelSetList.php
+++ b/src/Set/ValueObject/SilverstripeLevelSetList.php
@@ -19,4 +19,6 @@ final class SilverstripeLevelSetList
     public const UP_TO_SILVERSTRIPE_54 = __DIR__ . '/../../../config/set/level/up-to-silverstripe54.php';
 
     public const UP_TO_SILVERSTRIPE_60 = __DIR__ . '/../../../config/set/level/up-to-silverstripe60.php';
+
+    public const UP_TO_SILVERSTRIPE_61 = __DIR__ . '/../../../config/set/level/up-to-silverstripe61.php';
 }

--- a/src/Set/ValueObject/SilverstripeSetList.php
+++ b/src/Set/ValueObject/SilverstripeSetList.php
@@ -22,6 +22,8 @@ final class SilverstripeSetList
 
     public const SILVERSTRIPE_60 = __DIR__ . '/../../../config/set/silverstripe60.php';
 
+    public const SILVERSTRIPE_61 = __DIR__ . '/../../../config/set/silverstripe61.php';
+
     /**
      * Provides all the custom services that are required in order to run all the rules.
      */

--- a/src/TypeResolver/DependencyInjectionPropertyTypeResolver.php
+++ b/src/TypeResolver/DependencyInjectionPropertyTypeResolver.php
@@ -61,7 +61,7 @@ final class DependencyInjectionPropertyTypeResolver implements PropertyTypeResol
             return $types;
         }
 
-        /** @var array<array<mixed>|bool|int|string> $dependencies */
+        /** @var array<non-empty-string, array<mixed>|bool|int|string> $dependencies */
         foreach ($dependencies as $fieldName => $fieldType) {
             if (is_string($fieldType)) {
                 $type = $this->resolveDependencyObjectType($fieldType);

--- a/tests/rules/Silverstripe61/Rector/StaticCall/DataObjectDeleteByIdCachedRector/DataObjectDeleteByIdCachedRectorTest.php
+++ b/tests/rules/Silverstripe61/Rector/StaticCall/DataObjectDeleteByIdCachedRector/DataObjectDeleteByIdCachedRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectDeleteByIdCachedRector;
+
+use Cambis\SilverstripeRector\Testing\PHPUnit\AbstractSilverstripeRectorTestCase;
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class DataObjectDeleteByIdCachedRectorTest extends AbstractSilverstripeRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/rules/Silverstripe61/Rector/StaticCall/DataObjectDeleteByIdCachedRector/Fixture/super_class_call.php.inc
+++ b/tests/rules/Silverstripe61/Rector/StaticCall/DataObjectDeleteByIdCachedRector/Fixture/super_class_call.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectDeleteByIdCachedRector\Fixture;
+
+$id = 1;
+
+\SilverStripe\ORM\DataObject::delete_by_id(\Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectDeleteByIdCachedRector\Source\Foo::class, 1);
+
+\SilverStripe\ORM\DataObject::delete_by_id(\Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectDeleteByIdCachedRector\Source\Foo::class, $id);
+
+?>
+-----
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectDeleteByIdCachedRector\Fixture;
+
+$id = 1;
+
+\Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectDeleteByIdCachedRector\Source\Foo::get()->setUseCache(true)->byID(1)?->delete();
+
+\Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectDeleteByIdCachedRector\Source\Foo::get()->setUseCache(true)->byID($id)?->delete();
+
+?>

--- a/tests/rules/Silverstripe61/Rector/StaticCall/DataObjectDeleteByIdCachedRector/Source/Foo.php
+++ b/tests/rules/Silverstripe61/Rector/StaticCall/DataObjectDeleteByIdCachedRector/Source/Foo.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectDeleteByIdCachedRector\Source;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+final class Foo extends DataObject implements TestOnly
+{
+}

--- a/tests/rules/Silverstripe61/Rector/StaticCall/DataObjectDeleteByIdCachedRector/config/configured_rule.php
+++ b/tests/rules/Silverstripe61/Rector/StaticCall/DataObjectDeleteByIdCachedRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Cambis\SilverstripeRector\Silverstripe61\Rector\StaticCall\DataObjectDeleteByIdCachedRector;
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withRules([DataObjectDeleteByIdCachedRector::class]);

--- a/tests/rules/Silverstripe61/Rector/StaticCall/DataObjectGetByIdCachedRector/DataObjectGetByIdCachedRectorTest.php
+++ b/tests/rules/Silverstripe61/Rector/StaticCall/DataObjectGetByIdCachedRector/DataObjectGetByIdCachedRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetByIdCachedRector;
+
+use Cambis\SilverstripeRector\Testing\PHPUnit\AbstractSilverstripeRectorTestCase;
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class DataObjectGetByIdCachedRectorTest extends AbstractSilverstripeRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/rules/Silverstripe61/Rector/StaticCall/DataObjectGetByIdCachedRector/Fixture/class_call.php.inc
+++ b/tests/rules/Silverstripe61/Rector/StaticCall/DataObjectGetByIdCachedRector/Fixture/class_call.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetByIdCachedRector\Fixture;
+
+$id = 1;
+$cached = true;
+
+\Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetByIdCachedRector\Source\Foo::get_by_id(1);
+
+\Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetByIdCachedRector\Source\Foo::get_by_id($id);
+
+\Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetByIdCachedRector\Source\Foo::get_by_id($id, true);
+
+\Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetByIdCachedRector\Source\Foo::get_by_id($id, $cached);
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetByIdCachedRector\Fixture;
+
+$id = 1;
+$cached = true;
+
+\Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetByIdCachedRector\Source\Foo::get()->setUseCache(true)->byID(1);
+
+\Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetByIdCachedRector\Source\Foo::get()->setUseCache(true)->byID($id);
+
+\Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetByIdCachedRector\Source\Foo::get()->setUseCache(true)->byID($id);
+
+\Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetByIdCachedRector\Source\Foo::get()->setUseCache($cached)->byID($id);
+
+?>

--- a/tests/rules/Silverstripe61/Rector/StaticCall/DataObjectGetByIdCachedRector/Fixture/super_class_call.php.inc
+++ b/tests/rules/Silverstripe61/Rector/StaticCall/DataObjectGetByIdCachedRector/Fixture/super_class_call.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetByIdCachedRector\Fixture;
+
+$id = 1;
+
+\SilverStripe\ORM\DataObject::get_by_id(\Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetByIdCachedRector\Source\Foo::class, 1);
+
+\SilverStripe\ORM\DataObject::get_by_id(\Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetByIdCachedRector\Source\Foo::class, $id);
+
+\SilverStripe\ORM\DataObject::get_by_id('Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetByIdCachedRector\Source\Foo', 1);
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetByIdCachedRector\Fixture;
+
+$id = 1;
+
+\Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetByIdCachedRector\Source\Foo::get()->setUseCache(true)->byID(1);
+
+\Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetByIdCachedRector\Source\Foo::get()->setUseCache(true)->byID($id);
+
+\Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetByIdCachedRector\Source\Foo::get()->setUseCache(true)->byID(1);
+
+?>

--- a/tests/rules/Silverstripe61/Rector/StaticCall/DataObjectGetByIdCachedRector/Fixture/uncached_class_call.php.inc
+++ b/tests/rules/Silverstripe61/Rector/StaticCall/DataObjectGetByIdCachedRector/Fixture/uncached_class_call.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetByIdCachedRector\Fixture;
+
+$cached = false;
+
+\Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetByIdCachedRector\Source\Foo::get_by_id(1, false);
+
+\Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetByIdCachedRector\Source\Foo::get_by_id(1, $cached);
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetByIdCachedRector\Fixture;
+
+$cached = false;
+
+\Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetByIdCachedRector\Source\Foo::get()->byID(1);
+
+\Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetByIdCachedRector\Source\Foo::get()->setUseCache($cached)->byID(1);
+
+?>

--- a/tests/rules/Silverstripe61/Rector/StaticCall/DataObjectGetByIdCachedRector/Source/Foo.php
+++ b/tests/rules/Silverstripe61/Rector/StaticCall/DataObjectGetByIdCachedRector/Source/Foo.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetByIdCachedRector\Source;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+final class Foo extends DataObject implements TestOnly
+{
+}

--- a/tests/rules/Silverstripe61/Rector/StaticCall/DataObjectGetByIdCachedRector/config/configured_rule.php
+++ b/tests/rules/Silverstripe61/Rector/StaticCall/DataObjectGetByIdCachedRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Cambis\SilverstripeRector\Silverstripe61\Rector\StaticCall\DataObjectGetByIdCachedRector;
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withRules([DataObjectGetByIdCachedRector::class]);

--- a/tests/rules/Silverstripe61/Rector/StaticCall/DataObjectGetOneCachedRector/DataObjectGetOneCachedRectorTest.php
+++ b/tests/rules/Silverstripe61/Rector/StaticCall/DataObjectGetOneCachedRector/DataObjectGetOneCachedRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetOneCachedRector;
+
+use Cambis\SilverstripeRector\Testing\PHPUnit\AbstractSilverstripeRectorTestCase;
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class DataObjectGetOneCachedRectorTest extends AbstractSilverstripeRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/rules/Silverstripe61/Rector/StaticCall/DataObjectGetOneCachedRector/Fixture/class_call.php.inc
+++ b/tests/rules/Silverstripe61/Rector/StaticCall/DataObjectGetOneCachedRector/Fixture/class_call.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetOneCachedRector\Fixture;
+
+\Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetOneCachedRector\Source\Foo::get_one();
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetOneCachedRector\Fixture;
+
+\Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetOneCachedRector\Source\Foo::get()->setUseCache(true)->first();
+
+?>

--- a/tests/rules/Silverstripe61/Rector/StaticCall/DataObjectGetOneCachedRector/Fixture/super_class_call.php.inc
+++ b/tests/rules/Silverstripe61/Rector/StaticCall/DataObjectGetOneCachedRector/Fixture/super_class_call.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetOneCachedRector\Fixture;
+
+$cached = true;
+
+\SilverStripe\ORM\DataObject::get_one(\Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetOneCachedRector\Source\Foo::class);
+
+\SilverStripe\ORM\DataObject::get_one(\Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetOneCachedRector\Source\Foo::class, '', true);
+
+\SilverStripe\ORM\DataObject::get_one(\Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetOneCachedRector\Source\Foo::class, '', $cached);
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetOneCachedRector\Fixture;
+
+$cached = true;
+
+\Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetOneCachedRector\Source\Foo::get()->setUseCache(true)->first();
+
+\Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetOneCachedRector\Source\Foo::get()->setUseCache(true)->first();
+
+\Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetOneCachedRector\Source\Foo::get()->setUseCache($cached)->first();
+
+?>

--- a/tests/rules/Silverstripe61/Rector/StaticCall/DataObjectGetOneCachedRector/Fixture/uncached_class_call.php.inc
+++ b/tests/rules/Silverstripe61/Rector/StaticCall/DataObjectGetOneCachedRector/Fixture/uncached_class_call.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetOneCachedRector\Fixture;
+
+$cached = false;
+
+\SilverStripe\ORM\DataObject::get_one(\Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetOneCachedRector\Source\Foo::class, '', false);
+
+\SilverStripe\ORM\DataObject::get_one(\Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetOneCachedRector\Source\Foo::class, '', $cached);
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetOneCachedRector\Fixture;
+
+$cached = false;
+
+\Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetOneCachedRector\Source\Foo::get()->first();
+
+\Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetOneCachedRector\Source\Foo::get()->setUseCache($cached)->first();
+
+?>

--- a/tests/rules/Silverstripe61/Rector/StaticCall/DataObjectGetOneCachedRector/Source/Foo.php
+++ b/tests/rules/Silverstripe61/Rector/StaticCall/DataObjectGetOneCachedRector/Source/Foo.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\SilverstripeRector\Tests\Silverstripe61\Rector\StaticCall\DataObjectGetOneCachedRector\Source;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+final class Foo extends DataObject implements TestOnly
+{
+}

--- a/tests/rules/Silverstripe61/Rector/StaticCall/DataObjectGetOneCachedRector/config/configured_rule.php
+++ b/tests/rules/Silverstripe61/Rector/StaticCall/DataObjectGetOneCachedRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Cambis\SilverstripeRector\Silverstripe61\Rector\StaticCall\DataObjectGetOneCachedRector;
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withRules([DataObjectGetOneCachedRector::class]);


### PR DESCRIPTION
## Description ✍️

- Add rectors for new `DataList::setUseCache()` calls
- Bump minimum rector and silverstan versions
- Deprecate [DataObjectGetByIDCachedToUncachedRector](https://github.com/Cambis/silverstripe-rector/commit/f5c0f4a73433badcd5ce65bc11d32866e2527c47)

## DoD checklist ✅

- [x] I have performed a self-review of my code
- [x] My code adheres to the [coding standards](https://github.com/Cambis/silverstripe-rector/blob/main/CONTRIBUTING.md#coding-standards-️)
- [x] My commit messages adhere to the [commit standards](https://github.com/Cambis/silverstripe-rector/blob/main/CONTRIBUTING.md#commit-standards-️).
- [x] My code has been [tested](https://github.com/Cambis/silverstripe-rector/blob/main/CONTRIBUTING.md#testing-).
- [x] I have added a [changeset](https://github.com/Cambis/silverstripe-rector/blob/main/CONTRIBUTING.md#making-a-pull-request-).
