### PR TITLE
Update configuration property rectors

### DIFF
--- a/.changeset/beige-otters-care.md
+++ b/.changeset/beige-otters-care.md
@@ -1,0 +1,6 @@
+---
+"@cambis/silverstripe-rector": minor
+---
+
+- Add ConfigurationPropertyFetchToMethodCallRector
+- Rename property fetch on Config_ForClass in RenameConfigurationPropertyRector

--- a/build/composer-php-74.json
+++ b/build/composer-php-74.json
@@ -10,7 +10,7 @@
   "require": {
       "php": "^7.4 || ^8.0",
       "cambis/silverstan": "^2.1",
-      "rector/rector": "^2.1"
+      "rector/rector": "^2.1.2"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": "^8.3",
         "cambis/silverstan": "^2.1",
-        "rector/rector": "^2.1"
+        "rector/rector": "^2.1.2"
     },
     "require-dev": {
         "cweagans/composer-patches": "^1.7",

--- a/config/set/code-quality.php
+++ b/config/set/code-quality.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
+use Cambis\SilverstripeRector\CodeQuality\Rector\Assign\ConfigurationPropertyFetchToMethodCallRector;
 use Cambis\SilverstripeRector\CodeQuality\Rector\New_\InjectableNewInstanceToCreateRector;
-use Cambis\SilverstripeRector\CodeQuality\Rector\StaticPropertyFetch\StaticPropertyFetchToConfigGetRector;
 use Rector\Config\RectorConfig;
 use Rector\Transform\Rector\Assign\PropertyFetchToMethodCallRector;
 use Rector\Transform\ValueObject\PropertyFetchToMethodCall;
@@ -11,7 +11,7 @@ use Rector\Transform\ValueObject\PropertyFetchToMethodCall;
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rules([
         InjectableNewInstanceToCreateRector::class,
-        StaticPropertyFetchToConfigGetRector::class,
+        ConfigurationPropertyFetchToMethodCallRector::class,
     ]);
 
     $rectorConfig->ruleWithConfiguration(

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -28,6 +28,36 @@
 
 ## CodeQuality
 
+### ConfigurationPropertyFetchToMethodCallRector
+
+Transforms a property fetch on a configuration property into an appropriate getter/setter call.
+
+- class: [`Cambis\SilverstripeRector\CodeQuality\Rector\Assign\ConfigurationPropertyFetchToMethodCallRector`](../rules/CodeQuality/Rector/Assign/ConfigurationPropertyFetchToMethodCallRector.php)
+
+```diff
+ class Foo extends \SilverStripe\ORM\DataObject
+ {
+     private static string $bar = '';
+
+     public function doSomething(): void
+     {
+-        self::$bar = 'baz';
++        self::config()->set('bar', 'baz');
+
+-        echo self::$bar;
++        echo self::config()->get('bar');
+     }
+ }
+
+-Foo::config()->bar = 'baz';
++Foo::config()->set('bar', 'baz');
+
+-echo Foo::config()->bar;
++echo Foo::config()->get('bar');
+```
+
+<br>
+
 ### InjectableNewInstanceToCreateRector
 
 Change `new Injectable()` to use `Injectable::create()` instead.
@@ -37,27 +67,6 @@ Change `new Injectable()` to use `Injectable::create()` instead.
 ```diff
 -$foo = new \SilverStripe\ORM\ArrayList();
 +$foo = \SilverStripe\ORM\ArrayList::create();
-```
-
-<br>
-
-### StaticPropertyFetchToConfigGetRector
-
-Transforms static property fetch into `$this->config->get()`.
-
-- class: [`Cambis\SilverstripeRector\CodeQuality\Rector\StaticPropertyFetch\StaticPropertyFetchToConfigGetRector`](../rules/CodeQuality/Rector/StaticPropertyFetch/StaticPropertyFetchToConfigGetRector.php)
-
-```diff
- class Foo extends \SilverStripe\ORM\DataObject
- {
-     private static string $singular_name = 'Foo';
-
-     public function getType(): string
-     {
--        return self::$singular_name;
-+        return $this->config()->get('singular_name');
-     }
- }
 ```
 
 <br>

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -228,6 +228,9 @@ Rename a configuration property.
 
 -Foo::config()->get('description');
 +Foo::config()->get('class_description');
+
+-Foo::config()->description;
++Foo::config()->class_description;
 ```
 
 <br>

--- a/rules/CodeQuality/Rector/Assign/ConfigurationPropertyFetchToMethodCallRector.php
+++ b/rules/CodeQuality/Rector/Assign/ConfigurationPropertyFetchToMethodCallRector.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\SilverstripeRector\CodeQuality\Rector\Assign;
+
+use Cambis\Silverstan\ReflectionAnalyser\ClassReflectionAnalyser;
+use Cambis\Silverstan\ReflectionAnalyser\PropertyReflectionAnalyser;
+use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\StaticPropertyFetch;
+use PHPStan\Type\ObjectType;
+use Rector\Configuration\Parameter\FeatureFlags;
+use Rector\Enum\ObjectReference;
+use Rector\PHPStan\ScopeFetcher;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Cambis\SilverstripeRector\Tests\CodeQuality\Rector\Assign\ConfigurationPropertyFetchToMethodCallRector\ConfigurationPropertyFetchToMethodCallRectorTest
+ */
+final class ConfigurationPropertyFetchToMethodCallRector extends AbstractRector implements DocumentedRuleInterface
+{
+    public function __construct(
+        private readonly ClassReflectionAnalyser $classReflectionAnalyser,
+        private readonly PropertyReflectionAnalyser $propertyReflectionAnalyser
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Transforms a property fetch on a configuration property into an appropriate getter/setter call.',
+            [new CodeSample(
+                <<<'CODE_SAMPLE'
+class Foo extends \SilverStripe\ORM\DataObject
+{
+    private static string $bar = '';
+
+    public function doSomething(): void
+    {
+        self::$bar = 'baz';
+
+        echo self::$bar;
+    }
+}
+
+Foo::config()->bar = 'baz';
+
+echo Foo::config()->bar;
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+class Foo extends \SilverStripe\ORM\DataObject
+{
+    private static string $bar = '';
+
+    public function doSomething(): void
+    {
+        self::config()->set('bar', 'baz');
+
+        echo self::config()->get('bar');
+    }
+}
+
+Foo::config()->set('bar', 'baz');
+
+echo Foo::config()->get('bar');
+CODE_SAMPLE
+            ),
+            ]
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Assign::class, PropertyFetch::class, StaticPropertyFetch::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        if ($node instanceof Assign && $node->var instanceof PropertyFetch) {
+            return $this->refactorDynamicAssign($node);
+        }
+
+        if ($node instanceof Assign && $node->var instanceof StaticPropertyFetch) {
+            return $this->refactorStaticAssign($node);
+        }
+
+        if ($node instanceof PropertyFetch) {
+            return $this->refactorPropertyFetch($node);
+        }
+
+        if ($node instanceof StaticPropertyFetch) {
+            return $this->refactorStaticPropertyFetch($node);
+        }
+
+        return null;
+    }
+
+    private function refactorDynamicAssign(Assign $assign): ?MethodCall
+    {
+        if (!$assign->var instanceof PropertyFetch) {
+            return null;
+        }
+
+        if (!$this->isObjectType($assign->var->var, new ObjectType('SilverStripe\Core\Config\Config_ForClass'))) {
+            return null;
+        }
+
+        $propertyName = $this->getName($assign->var->name) ?? '';
+
+        if ($propertyName === '') {
+            return null;
+        }
+
+        return $this->nodeFactory->createMethodCall($assign->var->var, 'set', $this->nodeFactory->createArgs([$propertyName, $assign->expr]));
+    }
+
+    private function refactorStaticAssign(Assign $assign): ?MethodCall
+    {
+        if (!$assign->var instanceof StaticPropertyFetch) {
+            return null;
+        }
+
+        if ($this->shouldSkipStaticPropertyFetch($assign->var)) {
+            return null;
+        }
+
+        /** @var non-empty-string $propertyName */
+        $propertyName = $this->getName($assign->var->name);
+        $configCall = $this->nodeFactory->createStaticCall($this->getName($assign->var->class) ?? $this->getFallbackName($assign->var), 'config');
+
+        return $this->nodeFactory->createMethodCall($configCall, 'set', $this->nodeFactory->createArgs([$propertyName, $assign->expr]));
+    }
+
+    private function refactorPropertyFetch(PropertyFetch $propertyFetch): ?MethodCall
+    {
+        if (!$this->isObjectType($propertyFetch->var, new ObjectType('SilverStripe\Core\Config\Config_ForClass'))) {
+            return null;
+        }
+
+        $propertyName = $this->getName($propertyFetch->name) ?? '';
+
+        if ($propertyName === '') {
+            return null;
+        }
+
+        return $this->nodeFactory->createMethodCall($propertyFetch->var, 'get', $this->nodeFactory->createArgs([$propertyName]));
+    }
+
+    private function refactorStaticPropertyFetch(StaticPropertyFetch $staticPropertyFetch): ?MethodCall
+    {
+        if ($this->shouldSkipStaticPropertyFetch($staticPropertyFetch)) {
+            return null;
+        }
+
+        /** @var non-empty-string $propertyName */
+        $propertyName = $this->getName($staticPropertyFetch->name);
+        $configCall = $this->nodeFactory->createStaticCall($this->getName($staticPropertyFetch->class) ?? $this->getFallbackName($staticPropertyFetch), 'config');
+
+        return $this->nodeFactory->createMethodCall($configCall, 'get', [$propertyName]);
+    }
+
+    private function shouldSkipStaticPropertyFetch(StaticPropertyFetch $staticPropertyFetch): bool
+    {
+        $scope = ScopeFetcher::fetch($staticPropertyFetch);
+
+        if (!$scope->isInClass()) {
+            return true;
+        }
+
+        $classReflection = $scope->getClassReflection();
+
+        if (!$this->classReflectionAnalyser->isConfigurable($classReflection)) {
+            return true;
+        }
+
+        $propertyName = $this->getName($staticPropertyFetch->name) ?? '';
+
+        if ($propertyName === '') {
+            return true;
+        }
+
+        $propertyReflection = $classReflection->getProperty($propertyName, $scope);
+
+        return !$this->propertyReflectionAnalyser->isConfigurationProperty($propertyReflection);
+    }
+
+    private function getFallbackName(StaticPropertyFetch $staticPropertyFetch): string
+    {
+        $scope = ScopeFetcher::fetch($staticPropertyFetch);
+
+        if (!$scope->isInClass()) {
+            return ObjectReference::STATIC;
+        }
+
+        $classReflection = $scope->getClassReflection();
+
+        return $classReflection->isFinal() || FeatureFlags::treatClassesAsFinal() ? ObjectReference::SELF : ObjectReference::STATIC;
+    }
+}

--- a/rules/CodeQuality/Rector/StaticPropertyFetch/StaticPropertyFetchToConfigGetRector.php
+++ b/rules/CodeQuality/Rector/StaticPropertyFetch/StaticPropertyFetchToConfigGetRector.php
@@ -20,6 +20,8 @@ use function is_string;
 use function str_contains;
 
 /**
+ * @deprecated 2.1.0 use Cambis\SilverstripeRector\CodeQuality\Rector\Assign\ConfigurationPropertyFetchToMethodCallRector instead.
+ *
  * @see \Cambis\SilverstripeRector\Tests\CodeQuality\Rector\StaticPropertyFetch\StaticPropertyFetchToConfigGetRector\StaticPropertyFetchToConfigGetRectorTest
  */
 final class StaticPropertyFetchToConfigGetRector extends AbstractRector implements DocumentedRuleInterface

--- a/tests/rules/CodeQuality/Rector/Assign/ConfigurationPropertyFetchToMethodCallRector/ConfigurationPropertyFetchToMethodCallRectorTest.php
+++ b/tests/rules/CodeQuality/Rector/Assign/ConfigurationPropertyFetchToMethodCallRector/ConfigurationPropertyFetchToMethodCallRectorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cambis\SilverstripeRector\Tests\CodeQuality\Rector\Assign\ConfigurationPropertyFetchToMethodCallRector;
+
+use Cambis\SilverstripeRector\Testing\PHPUnit\AbstractSilverstripeRectorTestCase;
+use Iterator;
+use Override;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class ConfigurationPropertyFetchToMethodCallRectorTest extends AbstractSilverstripeRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    #[Override]
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/rules/CodeQuality/Rector/Assign/ConfigurationPropertyFetchToMethodCallRector/Fixture/config_for_class_get.php.inc
+++ b/tests/rules/CodeQuality/Rector/Assign/ConfigurationPropertyFetchToMethodCallRector/Fixture/config_for_class_get.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\CodeQuality\Rector\Assign\ConfigurationPropertyFetchToMethodCallRector\Fixture;
+
+use Cambis\SilverstripeRector\Tests\CodeQuality\Rector\Assign\ConfigurationPropertyFetchToMethodCallRector\Source\Foo;
+
+Foo::config()->bar;
+
+?>
+-----
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\CodeQuality\Rector\Assign\ConfigurationPropertyFetchToMethodCallRector\Fixture;
+
+use Cambis\SilverstripeRector\Tests\CodeQuality\Rector\Assign\ConfigurationPropertyFetchToMethodCallRector\Source\Foo;
+
+Foo::config()->get('bar');
+
+?>

--- a/tests/rules/CodeQuality/Rector/Assign/ConfigurationPropertyFetchToMethodCallRector/Fixture/config_for_class_set.php.inc
+++ b/tests/rules/CodeQuality/Rector/Assign/ConfigurationPropertyFetchToMethodCallRector/Fixture/config_for_class_set.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\CodeQuality\Rector\Assign\ConfigurationPropertyFetchToMethodCallRector\Fixture;
+
+use Cambis\SilverstripeRector\Tests\CodeQuality\Rector\Assign\ConfigurationPropertyFetchToMethodCallRector\Source\Foo;
+
+Foo::config()->bar = 'baz';
+
+?>
+-----
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\CodeQuality\Rector\Assign\ConfigurationPropertyFetchToMethodCallRector\Fixture;
+
+use Cambis\SilverstripeRector\Tests\CodeQuality\Rector\Assign\ConfigurationPropertyFetchToMethodCallRector\Source\Foo;
+
+Foo::config()->set('bar', 'baz');
+
+?>

--- a/tests/rules/CodeQuality/Rector/Assign/ConfigurationPropertyFetchToMethodCallRector/Fixture/static_property_fetch_assign.php.inc
+++ b/tests/rules/CodeQuality/Rector/Assign/ConfigurationPropertyFetchToMethodCallRector/Fixture/static_property_fetch_assign.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\CodeQuality\Rector\Assign\ConfigurationPropertyFetchToMethodCallRector\Fixture;
+
+class StaticPropertyFetchAssign extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+{
+    private static string $singular_name = 'Static property fetch';
+
+    public function doSomething(): void
+    {
+        self::$singular_name = 'new value';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\CodeQuality\Rector\Assign\ConfigurationPropertyFetchToMethodCallRector\Fixture;
+
+class StaticPropertyFetchAssign extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+{
+    private static string $singular_name = 'Static property fetch';
+
+    public function doSomething(): void
+    {
+        self::config()->set('singular_name', 'new value');
+    }
+}
+
+?>

--- a/tests/rules/CodeQuality/Rector/Assign/ConfigurationPropertyFetchToMethodCallRector/Fixture/static_property_fetch_class.php.inc
+++ b/tests/rules/CodeQuality/Rector/Assign/ConfigurationPropertyFetchToMethodCallRector/Fixture/static_property_fetch_class.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\CodeQuality\Rector\Assign\ConfigurationPropertyFetchToMethodCallRector\Fixture;
+
+class StaticPropertyFetchClass extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+{
+    private static string $singular_name = 'Static property fetch';
+
+    public function getType(): string
+    {
+        return StaticPropertyFetchClass::$singular_name;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\CodeQuality\Rector\Assign\ConfigurationPropertyFetchToMethodCallRector\Fixture;
+
+class StaticPropertyFetchClass extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+{
+    private static string $singular_name = 'Static property fetch';
+
+    public function getType(): string
+    {
+        return \Cambis\SilverstripeRector\Tests\CodeQuality\Rector\Assign\ConfigurationPropertyFetchToMethodCallRector\Fixture\StaticPropertyFetchClass::config()->get('singular_name');
+    }
+}
+
+?>

--- a/tests/rules/CodeQuality/Rector/Assign/ConfigurationPropertyFetchToMethodCallRector/Fixture/static_property_fetch_internal.php.inc
+++ b/tests/rules/CodeQuality/Rector/Assign/ConfigurationPropertyFetchToMethodCallRector/Fixture/static_property_fetch_internal.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\CodeQuality\Rector\Assign\ConfigurationPropertyFetchToMethodCallRector\Fixture;
+
+class StaticPropertyFetchInternal extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+{
+    /**
+     * @internal
+     */
+    private static string $singular_name = 'Static property fetch';
+
+    public function getType(): string
+    {
+        return static::$singular_name;
+    }
+}

--- a/tests/rules/CodeQuality/Rector/Assign/ConfigurationPropertyFetchToMethodCallRector/Fixture/static_property_fetch_self.php.inc
+++ b/tests/rules/CodeQuality/Rector/Assign/ConfigurationPropertyFetchToMethodCallRector/Fixture/static_property_fetch_self.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\CodeQuality\Rector\Assign\ConfigurationPropertyFetchToMethodCallRector\Fixture;
+
+class StaticPropertyFetchSelf extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+{
+    private static string $singular_name = 'Static property fetch';
+
+    public function getType(): string
+    {
+        return self::$singular_name;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\CodeQuality\Rector\Assign\ConfigurationPropertyFetchToMethodCallRector\Fixture;
+
+class StaticPropertyFetchSelf extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+{
+    private static string $singular_name = 'Static property fetch';
+
+    public function getType(): string
+    {
+        return self::config()->get('singular_name');
+    }
+}
+
+?>

--- a/tests/rules/CodeQuality/Rector/Assign/ConfigurationPropertyFetchToMethodCallRector/Fixture/static_property_fetch_static.php.inc
+++ b/tests/rules/CodeQuality/Rector/Assign/ConfigurationPropertyFetchToMethodCallRector/Fixture/static_property_fetch_static.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\CodeQuality\Rector\Assign\ConfigurationPropertyFetchToMethodCallRector\Fixture;
+
+class StaticPropertyFetchStatic extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+{
+    private static string $singular_name = 'Static property fetch';
+
+    public function getType(): string
+    {
+        return static::$singular_name;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\CodeQuality\Rector\Assign\ConfigurationPropertyFetchToMethodCallRector\Fixture;
+
+class StaticPropertyFetchStatic extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+{
+    private static string $singular_name = 'Static property fetch';
+
+    public function getType(): string
+    {
+        return static::config()->get('singular_name');
+    }
+}
+
+?>

--- a/tests/rules/CodeQuality/Rector/Assign/ConfigurationPropertyFetchToMethodCallRector/Source/Foo.php
+++ b/tests/rules/CodeQuality/Rector/Assign/ConfigurationPropertyFetchToMethodCallRector/Source/Foo.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\CodeQuality\Rector\Assign\ConfigurationPropertyFetchToMethodCallRector\Source;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+final class Foo extends DataObject implements TestOnly
+{
+}

--- a/tests/rules/CodeQuality/Rector/Assign/ConfigurationPropertyFetchToMethodCallRector/config/configured_rule.php
+++ b/tests/rules/CodeQuality/Rector/Assign/ConfigurationPropertyFetchToMethodCallRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Cambis\SilverstripeRector\CodeQuality\Rector\Assign\ConfigurationPropertyFetchToMethodCallRector;
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withRules([ConfigurationPropertyFetchToMethodCallRector::class]);

--- a/tests/rules/Renaming/Rector/Class_/RenameConfigurationPropertyRector/Fixture/rename_config_for_class_property_fetch.php.inc
+++ b/tests/rules/Renaming/Rector/Class_/RenameConfigurationPropertyRector/Fixture/rename_config_for_class_property_fetch.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\Renaming\Rector\Class_\RenameConfigurationPropertyRector\Fixture;
+
+use Cambis\SilverstripeRector\Tests\Renaming\Rector\Class_\RenameConfigurationPropertyRector\Source\Foo;
+
+Foo::config()->description;
+Foo::config()->description = '';
+
+?>
+-----
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\Renaming\Rector\Class_\RenameConfigurationPropertyRector\Fixture;
+
+use Cambis\SilverstripeRector\Tests\Renaming\Rector\Class_\RenameConfigurationPropertyRector\Source\Foo;
+
+Foo::config()->class_description;
+Foo::config()->class_description = '';
+
+?>


### PR DESCRIPTION
## Description ✍️

- Add ConfigurationPropertyFetchToMethodCallRector, to replace StaticPropertyFetchToConfigGetRector. The former handles more cases.
- Rename property fetch on Config_ForClass in RenameConfigurationPropertyRector

## DoD checklist ✅

- [x] I have performed a self-review of my code
- [x] My code adheres to the [coding standards](https://github.com/Cambis/silverstripe-rector/blob/main/CONTRIBUTING.md#coding-standards-️)
- [x] My commit messages adhere to the [commit standards](https://github.com/Cambis/silverstripe-rector/blob/main/CONTRIBUTING.md#commit-standards-️).
- [x] My code has been [tested](https://github.com/Cambis/silverstripe-rector/blob/main/CONTRIBUTING.md#testing-).
- [x] I have added a [changeset](https://github.com/Cambis/silverstripe-rector/blob/main/CONTRIBUTING.md#making-a-pull-request-).
