### PR TITLE
Resolve DI service names in DependencyInjectionPropertyTypeResolver

### DIFF
--- a/.changeset/ninety-trees-brush.md
+++ b/.changeset/ninety-trees-brush.md
@@ -1,0 +1,5 @@
+---
+"@cambis/silverstripe-rector": patch
+---
+
+Resolve service names in DependencyInjectionPropertyTypeResolver

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "phpstan/phpstan-deprecation-rules": "^1.2",
         "phpstan/phpstan-phpunit": "^1.3",
         "phpstan/phpstan-strict-rules": "^1.5",
-        "phpunit/phpunit": "^12.1",
+        "phpunit/phpunit": "~12.1.0",
         "slevomat/coding-standard": "^8.14",
         "symplify/easy-coding-standard": "^12.0",
         "symplify/phpstan-extensions": "^11.4",

--- a/rules/Silverstripe413/Rector/Class_/CompleteDynamicInjectablePropertiesRector.php
+++ b/rules/Silverstripe413/Rector/Class_/CompleteDynamicInjectablePropertiesRector.php
@@ -24,7 +24,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 use function array_keys;
 
 /**
- * @see Cambis\SilverstripeRector\Tests\Silverstripe413\Rector\Class_\CompleteDynamicInjectablePropertiesRector\CompleteDynamicInjectablePropertiesRectorTest
+ * @see \Cambis\SilverstripeRector\Tests\Silverstripe413\Rector\Class_\CompleteDynamicInjectablePropertiesRector\CompleteDynamicInjectablePropertiesRectorTest
  */
 final class CompleteDynamicInjectablePropertiesRector extends AbstractRector implements RelatedConfigInterface
 {

--- a/src/TypeResolver/DependencyInjectionPropertyTypeResolver.php
+++ b/src/TypeResolver/DependencyInjectionPropertyTypeResolver.php
@@ -94,9 +94,12 @@ final class DependencyInjectionPropertyTypeResolver implements PropertyTypeResol
         // Remove leading backslash
         $name = $this->normaliser->normaliseNamespace($name);
 
-        // Remove dot notation
-        $name = $this->normaliser->normaliseDotNotation($name);
+        // Check if the classname exists, if not resolve it
+        if (!$this->reflectionProvider->hasClass($name)) {
+            $name = $this->configurationResolver->resolveClassName($name);
+        }
 
+        // Fallback to string
         if (!$this->reflectionProvider->hasClass($name)) {
             return new StringType();
         }

--- a/tests/rules/Silverstripe413/Rector/Class_/CompleteDynamicInjectablePropertiesRector/Fixture/injectable_service_name.php.inc
+++ b/tests/rules/Silverstripe413/Rector/Class_/CompleteDynamicInjectablePropertiesRector/Fixture/injectable_service_name.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\Silverstripe413\Rector\Class_\CompleteDynamicInjectablePropertiesRector\Fixture;
+
+class InjectableServiceName extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+{
+}
+
+?>
+-----
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\Silverstripe413\Rector\Class_\CompleteDynamicInjectablePropertiesRector\Fixture;
+
+class InjectableServiceName extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+{
+    /**
+     * @var \Cambis\SilverstripeRector\Tests\Silverstripe413\Rector\Class_\CompleteDynamicInjectablePropertiesRector\Source\DependencyMock
+     */
+    public $dependency;
+}
+
+?>

--- a/tests/rules/Silverstripe413/Rector/Class_/CompleteDynamicInjectablePropertiesRector/Fixture/injectable_service_name_dot_notated.php.inc
+++ b/tests/rules/Silverstripe413/Rector/Class_/CompleteDynamicInjectablePropertiesRector/Fixture/injectable_service_name_dot_notated.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\Silverstripe413\Rector\Class_\CompleteDynamicInjectablePropertiesRector\Fixture;
+
+class InjectableServiceNameDotNotated extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+{
+}
+
+?>
+-----
+<?php
+
+namespace Cambis\SilverstripeRector\Tests\Silverstripe413\Rector\Class_\CompleteDynamicInjectablePropertiesRector\Fixture;
+
+class InjectableServiceNameDotNotated extends \SilverStripe\ORM\DataObject implements \SilverStripe\Dev\TestOnly
+{
+    /**
+     * @var \Cambis\SilverstripeRector\Tests\Silverstripe413\Rector\Class_\CompleteDynamicInjectablePropertiesRector\Source\DependencyMock
+     */
+    public $dependency;
+}
+
+?>

--- a/tests/rules/Silverstripe413/Rector/Class_/CompleteDynamicInjectablePropertiesRector/_config/config.yml
+++ b/tests/rules/Silverstripe413/Rector/Class_/CompleteDynamicInjectablePropertiesRector/_config/config.yml
@@ -15,7 +15,19 @@ Cambis\SilverstripeRector\Tests\Silverstripe413\Rector\Class_\CompleteDynamicInj
 SilverStripe\Core\Injector\Injector:
   Cambis\SilverstripeRector\Tests\Silverstripe413\Rector\Class_\CompleteDynamicInjectablePropertiesRector\Source\DependencyInterface:
     class: Cambis\SilverstripeRector\Tests\Silverstripe413\Rector\Class_\CompleteDynamicInjectablePropertiesRector\Source\DependencyInterfaceImplementor
+  Dependency:
+    class: Cambis\SilverstripeRector\Tests\Silverstripe413\Rector\Class_\CompleteDynamicInjectablePropertiesRector\Source\DependencyMock
+  Dependency.dotNotated:
+    class: Cambis\SilverstripeRector\Tests\Silverstripe413\Rector\Class_\CompleteDynamicInjectablePropertiesRector\Source\DependencyMock
 
 Cambis\SilverstripeRector\Tests\Silverstripe413\Rector\Class_\CompleteDynamicInjectablePropertiesRector\Fixture\InjectableInterface:
   dependencies:
     dependency: '%$Cambis\SilverstripeRector\Tests\Silverstripe413\Rector\Class_\CompleteDynamicInjectablePropertiesRector\Source\DependencyInterface'
+
+Cambis\SilverstripeRector\Tests\Silverstripe413\Rector\Class_\CompleteDynamicInjectablePropertiesRector\Fixture\InjectableServiceName:
+  dependencies:
+    dependency: '%$Dependency'
+
+Cambis\SilverstripeRector\Tests\Silverstripe413\Rector\Class_\CompleteDynamicInjectablePropertiesRector\Fixture\InjectableServiceNameDotNotated:
+  dependencies:
+    dependency: '%$Dependency.dotNotated'


### PR DESCRIPTION
## Description ✍️

- Resolve a service name if it has been set via the injector api.

## Fixes 🐛

- #42 

## DoD checklist ✅

- [x] I have performed a self-review of my code
- [x] My code adheres to the [coding standards](https://github.com/Cambis/silverstripe-rector/blob/main/CONTRIBUTING.md#coding-standards-️)
- [x] My commit messages adhere to the [commit standards](https://github.com/Cambis/silverstripe-rector/blob/main/CONTRIBUTING.md#commit-standards-️).
- [x] My code has been [tested](https://github.com/Cambis/silverstripe-rector/blob/main/CONTRIBUTING.md#testing-).
- [x] I have added a [changeset](https://github.com/Cambis/silverstripe-rector/blob/main/CONTRIBUTING.md#making-a-pull-request-).
