### PR TITLE
Add support for PHPStan 2.1.28

### DIFF
--- a/.changeset/odd-hounds-return.md
+++ b/.changeset/odd-hounds-return.md
@@ -1,0 +1,5 @@
+---
+"@cambis/silverstripe-rector": patch
+---
+
+Add support for PHPStan 2.1.28

--- a/build/composer-php-74.json
+++ b/build/composer-php-74.json
@@ -15,8 +15,8 @@
   "homepage": "https://github.com/Cambis/silverstripe-rector",
   "require": {
     "php": "^7.4 || ^8.0",
-    "cambis/silverstan": "^2.1",
-    "rector/rector": "^2.1.2"
+    "cambis/silverstan": "^2.1.7",
+    "rector/rector": "^2.1.7"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     "homepage": "https://github.com/Cambis/silverstripe-rector",
     "require": {
         "php": "^8.3",
-        "cambis/silverstan": "^2.1",
-        "rector/rector": "^2.1.2"
+        "cambis/silverstan": "^2.1.7",
+        "rector/rector": "^2.1.7"
     },
     "require-dev": {
         "cweagans/composer-patches": "^1.7",
@@ -34,6 +34,9 @@
         "symplify/phpstan-rules": "^14.0",
         "symplify/rule-doc-generator": "^12.2",
         "symplify/vendor-patches": "^11.3"
+    },
+    "conflict": {
+        "squizlabs/php_codesniffer": ">=4.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/rector.php
+++ b/rector.php
@@ -17,17 +17,18 @@ return RectorConfig::configure()
     ])
     ->withPhpSets()
     ->withPreparedSets(
+        deadCode: true,
         codeQuality: true,
         codingStyle: true,
-        deadCode: true,
-        earlyReturn: true,
         privatization: true,
+        earlyReturn: true,
         phpunitCodeQuality: true
     )
     ->withRules([
         DeclareStrictTypesRector::class,
     ])
     ->withSkip([
+        __DIR__ . '/stubs',
         '*/Rector/*/Fixture/*',
         '*/Source/*',
         ClosureToArrowFunctionRector::class,

--- a/rules/CodeQuality/Rector/Assign/ConfigurationPropertyFetchToMethodCallRector.php
+++ b/rules/CodeQuality/Rector/Assign/ConfigurationPropertyFetchToMethodCallRector.php
@@ -11,7 +11,6 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticPropertyFetch;
 use PHPStan\Type\ObjectType;
-use Rector\Configuration\Parameter\FeatureFlags;
 use Rector\Enum\ObjectReference;
 use Rector\PHPStan\ScopeFetcher;
 use Rector\Rector\AbstractRector;
@@ -174,6 +173,6 @@ CODE_SAMPLE
 
         $classReflection = $scope->getClassReflection();
 
-        return $classReflection->isFinal() || FeatureFlags::treatClassesAsFinal() ? ObjectReference::SELF : ObjectReference::STATIC;
+        return $classReflection->isFinal() ? ObjectReference::SELF : ObjectReference::STATIC;
     }
 }

--- a/rules/LinkField/Rector/StaticCall/GorriecoeLinkFieldToSilverstripeLinkFieldRector.php
+++ b/rules/LinkField/Rector/StaticCall/GorriecoeLinkFieldToSilverstripeLinkFieldRector.php
@@ -143,6 +143,7 @@ CODE_SAMPLE
             $allowedTypes = [];
 
             foreach ($legacyAllowedTypes as $allowedType) {
+                // @phpstan-ignore-next-line offsetAccess.invalidOffset
                 if (!isset(self::LINK_TYPES[$allowedType])) {
                     continue;
                 }

--- a/rules/Silverstripe413/Rector/Class_/AddDBFieldPropertyAnnotationsToDataObjectRector.php
+++ b/rules/Silverstripe413/Rector/Class_/AddDBFieldPropertyAnnotationsToDataObjectRector.php
@@ -93,8 +93,8 @@ CODE_SAMPLE
         }
 
         // Attempt to return the type from the value property
-        if ($fieldClassReflection->hasProperty('value')) {
-            return $fieldClassReflection->getProperty('value', new OutOfClassScope())->getReadableType();
+        if ($fieldClassReflection->hasInstanceProperty('value')) {
+            return $fieldClassReflection->getInstanceProperty('value', new OutOfClassScope())->getReadableType();
         }
 
         // Fallback, return the original type

--- a/rules/Silverstripe413/Rector/Class_/CompleteDynamicInjectablePropertiesRector.php
+++ b/rules/Silverstripe413/Rector/Class_/CompleteDynamicInjectablePropertiesRector.php
@@ -124,7 +124,7 @@ CODE_SAMPLE
         $missingProperties = [];
         // remove other properties that are accessible from this scope
         foreach ($propertiesToComplete as $propertyName => $propertyToComplete) {
-            if ($classReflection->hasProperty($propertyName)) {
+            if ($classReflection->hasInstanceProperty($propertyName)) {
                 continue;
             }
 

--- a/src/NodeAnalyser/StaticPropertyFetchAnalyser.php
+++ b/src/NodeAnalyser/StaticPropertyFetchAnalyser.php
@@ -39,11 +39,11 @@ final readonly class StaticPropertyFetchAnalyser
             return false;
         }
 
-        if (!$classReflection->hasProperty($propertyName)) {
+        if (!$classReflection->hasStaticProperty($propertyName)) {
             return false;
         }
 
-        $propertyReflection = $classReflection->getProperty($propertyName, $scope);
+        $propertyReflection = $classReflection->getStaticProperty($propertyName);
 
         return $this->propertyReflectionAnalyser->isConfigurationProperty($propertyReflection);
     }

--- a/src/PhpDocHelper/PhpDocHelper.php
+++ b/src/PhpDocHelper/PhpDocHelper.php
@@ -34,7 +34,7 @@ final readonly class PhpDocHelper
     }
 
     /**
-     * @param Type[] $paramsNameToType
+     * @param array<string, Type> $paramsNameToType
      * @return PhpDocTagValueNode[]
      */
     public function convertTypesToPropertyTagValueNodes(array $paramsNameToType): array

--- a/stubs/SilverStripe/ORM/FieldType/DBField.php
+++ b/stubs/SilverStripe/ORM/FieldType/DBField.php
@@ -14,4 +14,8 @@ abstract class DBField
      * @var mixed
      */
     protected $value;
+
+    public function __get($name)
+    {
+    }
 }


### PR DESCRIPTION
## Description ✍️
- remove calls to depreacted hasProperty/getProperty
- fix issue with ecs phpcs compat

## DoD checklist ✅

- [x] I have performed a self-review of my code
- [x] My code adheres to the [coding standards](https://github.com/Cambis/silverstripe-rector/blob/main/CONTRIBUTING.md#coding-standards-️)
- [x] My commit messages adhere to the [commit standards](https://github.com/Cambis/silverstripe-rector/blob/main/CONTRIBUTING.md#commit-standards-️).
- [x] My code has been [tested](https://github.com/Cambis/silverstripe-rector/blob/main/CONTRIBUTING.md#testing-).
- [x] I have added a [changeset](https://github.com/Cambis/silverstripe-rector/blob/main/CONTRIBUTING.md#making-a-pull-request-).
